### PR TITLE
Macroll: deal with permutations as lists of indices

### DIFF
--- a/nanoyalla/_CoqProject
+++ b/nanoyalla/_CoqProject
@@ -4,3 +4,4 @@ nanoll.v
 macroll.v
 example1.v
 example2.v
+example3.v

--- a/nanoyalla/example2.v
+++ b/nanoyalla/example2.v
@@ -7,7 +7,8 @@ Variable A B : formula.
 Goal ll [wn (aplus (dual A) (dual B)); tens (oc A) (oc B)].
 Proof.
 apply co_r.
-apply (ex_transp 1 0 ([wn (aplus (dual A) (dual B))] ++ tens (oc A) (oc B) :: [wn (aplus (dual A) (dual B))])).
+apply (ex_perm_rev [1;2;0]); cbn.
+change (ll ([wn (aplus (dual A) (dual B))] ++ tens (oc A) (oc B) :: [wn (aplus (dual A) (dual B))])).
 apply tens_r_ext.
 - change (ll (map wn [aplus (dual A) (dual B)] ++ oc A :: map wn nil)).
   apply oc_r_ext; cbn.

--- a/nanoyalla/example3.v
+++ b/nanoyalla/example3.v
@@ -1,0 +1,24 @@
+Require Import macroll.
+
+Section TheProof.
+
+Variable A B C : formula.
+
+Goal ll [C; dual B] -> ll [wn (aplus (dual A) (dual B)); tens (oc A) (oc C)].
+Proof.
+intros H0.
+apply (co_r_ext (aplus (dual A) (dual B)) [] [tens (oc A) (oc C)]).
+apply (ex_perm [2;0;1]
+               [wn (aplus (dual A) (dual B)); tens (oc A) (oc C); wn (aplus (dual A) (dual B))]).
+apply (tens_r_ext (oc A) (oc C) [wn (aplus (dual A) (dual B))] [wn (aplus (dual A) (dual B))]).
+- apply (oc_r_ext A [aplus (dual A) (dual B)] []).
+  apply (de_r_ext (aplus (dual A) (dual B)) [] [A]).
+  apply (plus_r1_ext (dual A) (dual B) [] [A]).
+  apply ax_exp.
+- apply (oc_r_ext C [] [aplus (dual A) (dual B)]).
+  apply (de_r_ext (aplus (dual A) (dual B)) [C] []).
+  apply (plus_r2_ext (dual B) (dual A) [C] []).
+  apply H0.
+Qed.
+
+End TheProof.

--- a/nanoyalla/nanoll.v
+++ b/nanoyalla/nanoll.v
@@ -2,14 +2,12 @@
 
 Open Scope list_scope.
 
-From Coq Require List.
-(* only List.map from module List is used:
-Fixpoint map {A B : Type} (f: A -> B) l :=
-match l with
-| nil => nil
-| a :: t => f a :: map f t
-end.
-*)
+(* Same definition as [List.map] *)
+Definition map [A B : Type] (f : A -> B) :=
+  fix map l := match l with
+               | nil => nil
+               | a :: t => f a :: map t
+               end.
 
 
 (* Adapted from yalla/formulas.v *)
@@ -47,7 +45,7 @@ Inductive ll : list formula -> Type :=
 | plus_r1 : forall A B l, ll (A :: l) -> ll (aplus A B :: l)
 | plus_r2 : forall A B l, ll (A :: l) -> ll (aplus B A :: l)
 | with_r : forall A B l, ll (A :: l) -> ll (B :: l) -> ll (awith A B :: l)
-| oc_r : forall A l, ll (A :: List.map wn l) -> ll (oc A :: List.map wn l)
+| oc_r : forall A l, ll (A :: map wn l) -> ll (oc A :: map wn l)
 | de_r : forall A l, ll (A :: l) -> ll (wn A :: l)
 | wk_r : forall A l, ll l -> ll (wn A :: l)
 | co_r : forall A l, ll (wn A :: wn A :: l) -> ll (wn A :: l).


### PR DESCRIPTION
Allows to use directly permutations as lists of indices in Yalla through:
```coq
Lemma ex_perm p l : ll l -> ll (transpL (permL_of_perm p) l).
Lemma ex_perm_rev p l : ll (transpL (permL_of_perm p) l) -> ll l.
```
where `p = [3;1;2]` maps `[a;b;c]` to `[c;a;b]`.