### PR TITLE
correct permutation in exchange rule

### DIFF
--- a/proof.ml
+++ b/proof.ml
@@ -206,7 +206,8 @@ let from_sequent_and_rule_request sequent rule_request =
             then raise (Technical_exception ("When applying exchange rule, formula_positions and sequent must have same size"))
             else if not (is_valid_permutation permutation)
             then raise (Technical_exception ("When applying exchange rule, formula_positions should be a permutation of the size of sequent formula list"))
-            else Exchange (sequent, permutation_inverse permutation, (Hypothesis {hyp=[]; cons=permute sequent.cons permutation}))
+            else let permuted_sequent = {hyp=[]; cons=permute sequent.cons permutation} in
+            Exchange (permuted_sequent, permutation_inverse permutation, (Hypothesis permuted_sequent))
         );;
 
 let from_sequent_and_rule_request_and_premises sequent rule_request premises =

--- a/proof.ml
+++ b/proof.ml
@@ -300,5 +300,5 @@ let rec to_coq = function
     | Weakening (head, _, _, p) -> coq_apply_with_args "wk_r_ext" [formula_list_to_coq head] ^ (to_coq p)
     | Contraction (head, _, _, p) -> coq_apply_with_args "co_r_ext" [formula_list_to_coq head] ^ (to_coq p)
     | Exchange (sequent, permutation, p) ->
-        coq_apply_with_args "ex_perm" [permutation_to_coq permutation; formula_list_to_coq (permute sequent.cons permutation)] ^ (to_coq p)
+        coq_apply_with_args "ex_perm" [permutation_to_coq permutation; formula_list_to_coq sequent.cons] ^ (to_coq p)
     | Hypothesis sequent -> "not implemented\n";;


### PR DESCRIPTION
Permutation is inverted in the internal data-type `proof`.
Moreover to stay consistent with the Coq type, the `sequent` argument of `Exchange` is the premise to that `get_conclusion` has to apply the permutation.

Fixes #25 