### PR TITLE
Better Coq export

### DIFF
--- a/export_as_coq.ml
+++ b/export_as_coq.ml
@@ -15,7 +15,6 @@ let proof_to_coq proof =
     let conclusion = get_conclusion proof in
     let header = "(* This Coq file has been generated using C1ick ⅋ c⊗LLec⊥ tool. *)\n"
         ^ "(* https://click-and-collect.linear-logic.org/ *)\n"
-        ^ "(* /!\\ This is a work-in-progress feature. /!\\ *)\n"
         ^ "(* First download and install NanoYalla version 1.0.1, see README.md: *)\n"
         ^ "(* https://click-and-collect.linear-logic.org/download/nanoyalla.zip *)\n\n" in
     let start_file_line = "From NanoYalla Require Import macroll.\n\nSection TheProof.\n\n" in

--- a/export_as_coq.ml
+++ b/export_as_coq.ml
@@ -8,6 +8,9 @@ let proof_variables conclusion =
     | [] -> ""
     | _ -> Printf.sprintf "Variable %s : formula.\n\n" (String.concat " " unique_variable_names);;
 
+let list_of_intros k =
+  String.concat " " (List.init k (fun n -> "Hyp" ^ (string_of_int n)))
+
 let proof_to_coq proof =
     let conclusion = get_conclusion proof in
     let header = "(* This Coq file has been generated using C1ick ⅋ c⊗LLec⊥ tool. *)\n"
@@ -17,9 +20,13 @@ let proof_to_coq proof =
         ^ "(* https://click-and-collect.linear-logic.org/download/nanoyalla.zip *)\n\n" in
     let start_file_line = "From NanoYalla Require Import macroll.\n\nSection TheProof.\n\n" in
     let variable_line = proof_variables conclusion in
-    let goal_line = Printf.sprintf "Goal %s.\n" (Sequent.sequent_to_coq conclusion) in
-    let start_proof_line = "Proof.\n" in
-    let proof_lines = Proof.to_coq proof in
+    let proof_lines, number_of_hypotheses, hypotheses = to_coq_with_hyps proof in
+    let goal_line = Printf.sprintf "Goal %s.\n" (String.concat " -> " (hypotheses @ [sequent_to_coq conclusion])) in
+    let intros_list =
+        if number_of_hypotheses > 0 then
+          Printf.sprintf "intros %s.\n" (list_of_intros number_of_hypotheses)
+        else "" in
+    let start_proof_line = "Proof.\n" ^ intros_list in
     let end_proof_line = "Qed.\n\nEnd TheProof.\n" in
     Printf.sprintf "%s%s%s%s%s%s%s" header start_file_line variable_line goal_line start_proof_line proof_lines end_proof_line;;
 

--- a/export_as_coq.ml
+++ b/export_as_coq.ml
@@ -20,7 +20,7 @@ let proof_to_coq proof =
     let start_file_line = "From NanoYalla Require Import macroll.\n\nSection TheProof.\n\n" in
     let variable_line = proof_variables conclusion in
     let proof_lines, number_of_hypotheses, hypotheses = to_coq_with_hyps proof in
-    let goal_line = Printf.sprintf "Goal %s.\n" (String.concat " -> " (hypotheses @ [sequent_to_coq conclusion])) in
+    let goal_line = Printf.sprintf "Goal %s.\n" (String.concat " -> " (hypotheses @ [Sequent.sequent_to_coq conclusion])) in
     let intros_list =
         if number_of_hypotheses > 0 then
           Printf.sprintf "intros %s.\n" (list_of_intros number_of_hypotheses)

--- a/proof.ml
+++ b/proof.ml
@@ -286,7 +286,7 @@ let add_indent_and_brace proof_as_coq =
 
 let rec to_coq = function
     | Axiom_left _ -> coq_apply "ax_r2_ext"
-    | Axiom_right f -> coq_apply_with_args "ax_r1_ext" [formula_to_coq f]
+    | Axiom_right f -> coq_apply_with_args "ax_r1_ext" ["(" ^ formula_to_coq f ^ ")"]
     | One -> coq_apply "one_r_ext"
     | Top (head, _) -> coq_apply_with_args "top_r_ext" [formula_list_to_coq head]
     | Bottom (head, _, p) -> coq_apply_with_args "bot_r_ext" [formula_list_to_coq head] ^ (to_coq p)
@@ -296,10 +296,10 @@ let rec to_coq = function
     | Plus_left (head, _, _, _, p) -> coq_apply_with_args "plus_r1_ext" [formula_list_to_coq head] ^ (to_coq p)
     | Plus_right (head, _, _, _, p) -> coq_apply_with_args "plus_r2_ext" [formula_list_to_coq head] ^ (to_coq p)
     | Promotion (head_without_whynot, e, tail_without_whynot, p) ->
-        coq_apply_with_args "oc_r_ext" [formula_list_to_coq head_without_whynot; formula_to_coq e; formula_list_to_coq tail_without_whynot] ^ (to_coq p)
+        coq_apply_with_args "oc_r_ext" [formula_list_to_coq head_without_whynot; "(" ^ formula_to_coq e ^ ")"; formula_list_to_coq tail_without_whynot] ^ (to_coq p)
     | Dereliction (head, _, _, p) -> coq_apply_with_args "de_r_ext" [formula_list_to_coq head] ^ (to_coq p)
     | Weakening (head, _, _, p) -> coq_apply_with_args "wk_r_ext" [formula_list_to_coq head] ^ (to_coq p)
     | Contraction (head, _, _, p) -> coq_apply_with_args "co_r_ext" [formula_list_to_coq head] ^ (to_coq p)
     | Exchange (sequent, permutation, p) ->
         coq_apply_with_args "ex_perm_r" [permutation_to_coq permutation; formula_list_to_coq sequent.cons] ^ (to_coq p)
-    | Hypothesis sequent -> "not implemented\n";;
+    | Hypothesis sequent -> "admit.\n";;

--- a/proof.ml
+++ b/proof.ml
@@ -284,22 +284,46 @@ let add_indent_and_brace proof_as_coq =
       | first_line :: other_lines -> first_line :: List.map indent_line other_lines
     in Printf.sprintf "{ %s }\n" (String.concat "\n" indented_lines)
 
-let rec to_coq = function
-    | Axiom_left _ -> coq_apply "ax_r2_ext"
-    | Axiom_right f -> coq_apply_with_args "ax_r1_ext" ["(" ^ formula_to_coq f ^ ")"]
-    | One -> coq_apply "one_r_ext"
-    | Top (head, _) -> coq_apply_with_args "top_r_ext" [formula_list_to_coq head]
-    | Bottom (head, _, p) -> coq_apply_with_args "bot_r_ext" [formula_list_to_coq head] ^ (to_coq p)
-    | Tensor (head, _, _, _, p1, p2) -> coq_apply_with_args "tens_r_ext" [formula_list_to_coq head] ^ add_indent_and_brace (to_coq p1) ^ add_indent_and_brace (to_coq p2)
-    | Par (head, _, _, _, p) -> coq_apply_with_args "parr_r_ext" [formula_list_to_coq head] ^ (to_coq p)
-    | With (head, _, _, _, p1, p2) -> coq_apply_with_args "with_r_ext" [formula_list_to_coq head] ^ add_indent_and_brace (to_coq p1) ^ add_indent_and_brace (to_coq p2)
-    | Plus_left (head, _, _, _, p) -> coq_apply_with_args "plus_r1_ext" [formula_list_to_coq head] ^ (to_coq p)
-    | Plus_right (head, _, _, _, p) -> coq_apply_with_args "plus_r2_ext" [formula_list_to_coq head] ^ (to_coq p)
+let rec to_coq_with_hyps_increment i = function
+    | Axiom_left _ -> coq_apply "ax_r2_ext", i, []
+    | Axiom_right f -> coq_apply_with_args "ax_r1_ext" ["(" ^ formula_to_coq f ^ ")"], i, []
+    | One -> coq_apply "one_r_ext", i, []
+    | Top (head, _) -> coq_apply_with_args "top_r_ext" [formula_list_to_coq head], i, []
+    | Bottom (head, _, p) ->
+        let s, n, hyps = to_coq_with_hyps_increment i p in
+        coq_apply_with_args "bot_r_ext" [formula_list_to_coq head] ^ s, n, hyps
+    | Tensor (head, _, _, _, p1, p2) -> 
+        let s1, n1, hyps1 = to_coq_with_hyps_increment i p1 in
+        let s2, n2, hyps2 = to_coq_with_hyps_increment n1 p2 in
+        coq_apply_with_args "tens_r_ext" [formula_list_to_coq head] ^ add_indent_and_brace s1 ^ add_indent_and_brace s2, n2, hyps1 @ hyps2
+    | Par (head, _, _, _, p) ->
+        let s, n, hyps = to_coq_with_hyps_increment i p in
+        coq_apply_with_args "parr_r_ext" [formula_list_to_coq head] ^ s, n, hyps
+    | With (head, _, _, _, p1, p2) ->
+        let s1, n1, hyps1 = to_coq_with_hyps_increment i p1 in
+        let s2, n2, hyps2 = to_coq_with_hyps_increment n1 p2 in
+        coq_apply_with_args "with_r_ext" [formula_list_to_coq head] ^ add_indent_and_brace s1 ^ add_indent_and_brace s2, n2, hyps1 @ hyps2
+    | Plus_left (head, _, _, _, p) ->
+        let s, n, hyps = to_coq_with_hyps_increment i p in
+        coq_apply_with_args "plus_r1_ext" [formula_list_to_coq head] ^ s, n, hyps
+    | Plus_right (head, _, _, _, p) ->
+        let s, n, hyps = to_coq_with_hyps_increment i p in
+        coq_apply_with_args "plus_r2_ext" [formula_list_to_coq head] ^ s, n, hyps
     | Promotion (head_without_whynot, e, tail_without_whynot, p) ->
-        coq_apply_with_args "oc_r_ext" [formula_list_to_coq head_without_whynot; "(" ^ formula_to_coq e ^ ")"; formula_list_to_coq tail_without_whynot] ^ (to_coq p)
-    | Dereliction (head, _, _, p) -> coq_apply_with_args "de_r_ext" [formula_list_to_coq head] ^ (to_coq p)
-    | Weakening (head, _, _, p) -> coq_apply_with_args "wk_r_ext" [formula_list_to_coq head] ^ (to_coq p)
-    | Contraction (head, _, _, p) -> coq_apply_with_args "co_r_ext" [formula_list_to_coq head] ^ (to_coq p)
+        let s, n, hyps = to_coq_with_hyps_increment i p in
+        coq_apply_with_args "oc_r_ext" [formula_list_to_coq head_without_whynot; "(" ^ formula_to_coq e ^ ")"; formula_list_to_coq tail_without_whynot] ^ s, n, hyps
+    | Dereliction (head, _, _, p) ->
+        let s, n, hyps = to_coq_with_hyps_increment i p in
+        coq_apply_with_args "de_r_ext" [formula_list_to_coq head] ^ s, n, hyps
+    | Weakening (head, _, _, p) ->
+        let s, n, hyps = to_coq_with_hyps_increment i p in
+        coq_apply_with_args "wk_r_ext" [formula_list_to_coq head] ^ s, n, hyps
+    | Contraction (head, _, _, p) ->
+        let s, n, hyps = to_coq_with_hyps_increment i p in
+        coq_apply_with_args "co_r_ext" [formula_list_to_coq head] ^ s, n, hyps
     | Exchange (sequent, permutation, p) ->
-        coq_apply_with_args "ex_perm_r" [permutation_to_coq permutation; formula_list_to_coq sequent.cons] ^ (to_coq p)
-    | Hypothesis sequent -> "admit.\n";;
+        let s, n, hyps = to_coq_with_hyps_increment i p in
+        coq_apply_with_args "ex_perm_r" [permutation_to_coq permutation; formula_list_to_coq sequent.cons] ^ s, n, hyps
+    | Hypothesis sequent -> coq_apply ("Hyp" ^ string_of_int i), i + 1, [sequent_to_coq sequent];;
+
+let to_coq_with_hyps = to_coq_with_hyps_increment 0

--- a/proof.ml
+++ b/proof.ml
@@ -324,6 +324,6 @@ let rec to_coq_with_hyps_increment i = function
     | Exchange (sequent, permutation, p) ->
         let s, n, hyps = to_coq_with_hyps_increment i p in
         coq_apply_with_args "ex_perm_r" [permutation_to_coq permutation; formula_list_to_coq sequent.cons] ^ s, n, hyps
-    | Hypothesis sequent -> coq_apply ("Hyp" ^ string_of_int i), i + 1, [sequent_to_coq sequent];;
+    | Hypothesis sequent -> coq_apply ("Hyp" ^ string_of_int i), i + 1, [Sequent.sequent_to_coq sequent];;
 
 let to_coq_with_hyps = to_coq_with_hyps_increment 0

--- a/sequent.ml
+++ b/sequent.ml
@@ -93,21 +93,53 @@ let from_json sequent_as_json =
 
 (* SEQUENT -> COQ *)
 
-let rec formula_to_coq =
+let rec formula_to_coq_atomic =
   function
-  | One -> "one"
-  | Bottom -> "bot"
-  | Top -> "top"
-  | Zero -> "zero"
-  | Litt x -> x
-  | Orth e -> Printf.sprintf "(dual %s)" (formula_to_coq e)
-  | Tensor (e1, e2) -> Printf.sprintf "(tens %s %s)" (formula_to_coq e1) (formula_to_coq e2)
-  | Par (e1, e2) -> Printf.sprintf "(parr %s %s)" (formula_to_coq e1) (formula_to_coq e2)
-  | With (e1, e2) -> Printf.sprintf "(awith %s %s)" (formula_to_coq e1) (formula_to_coq e2)
-  | Plus (e1, e2) -> Printf.sprintf "(aplus %s %s)" (formula_to_coq e1) (formula_to_coq e2)
-  | Lollipop (e1, e2) -> formula_to_coq (Par (Orth e1, e2))
-  | Ofcourse e -> Printf.sprintf "(oc %s)" (formula_to_coq e)
-  | Whynot e -> Printf.sprintf "(wn %s)" (formula_to_coq e);;
+  | One -> "one", true
+  | Bottom -> "bot", true
+  | Top -> "top", true
+  | Zero -> "zero", true
+  | Litt x -> x, true
+  | Orth e ->
+      let s, atomic = formula_to_coq_atomic e in
+      let s_parenthesis = if atomic then s else "(" ^ s ^ ")" in
+      Printf.sprintf "dual %s" s_parenthesis, false
+  | Tensor (e1, e2) ->
+      let s1, atomic1 = formula_to_coq_atomic e1 in
+      let s1_parenthesis = if atomic1 then s1 else "(" ^ s1 ^ ")" in
+      let s2, atomic2 = formula_to_coq_atomic e2 in
+      let s2_parenthesis = if atomic2 then s2 else "(" ^ s2 ^ ")" in
+      Printf.sprintf "tens %s %s" s1_parenthesis s2_parenthesis, false
+  | Par (e1, e2) ->
+      let s1, atomic1 = formula_to_coq_atomic e1 in
+      let s1_parenthesis = if atomic1 then s1 else "(" ^ s1 ^ ")" in
+      let s2, atomic2 = formula_to_coq_atomic e2 in
+      let s2_parenthesis = if atomic2 then s2 else "(" ^ s2 ^ ")" in
+      Printf.sprintf "parr %s %s" s1_parenthesis s2_parenthesis, false
+  | With (e1, e2) ->
+      let s1, atomic1 = formula_to_coq_atomic e1 in
+      let s1_parenthesis = if atomic1 then s1 else "(" ^ s1 ^ ")" in
+      let s2, atomic2 = formula_to_coq_atomic e2 in
+      let s2_parenthesis = if atomic2 then s2 else "(" ^ s2 ^ ")" in
+      Printf.sprintf "awith %s %s" s1_parenthesis s2_parenthesis, false
+  | Plus (e1, e2) ->
+      let s1, atomic1 = formula_to_coq_atomic e1 in
+      let s1_parenthesis = if atomic1 then s1 else "(" ^ s1 ^ ")" in
+      let s2, atomic2 = formula_to_coq_atomic e2 in
+      let s2_parenthesis = if atomic2 then s2 else "(" ^ s2 ^ ")" in
+      Printf.sprintf "aplus %s %s" s1_parenthesis s2_parenthesis, false
+  | Lollipop (e1, e2) -> formula_to_coq_atomic (Par (Orth e1, e2))
+  | Ofcourse e ->
+      let s, atomic = formula_to_coq_atomic e in
+      let s_parenthesis = if atomic then s else "(" ^ s ^ ")" in
+      Printf.sprintf "oc %s" s_parenthesis, false
+  | Whynot e ->
+      let s, atomic = formula_to_coq_atomic e in
+      let s_parenthesis = if atomic then s else "(" ^ s ^ ")" in
+      Printf.sprintf "wn %s" s_parenthesis, false
+
+let formula_to_coq formula =
+  let s, _ = formula_to_coq_atomic formula in s
 
 let formula_list_to_coq formula_list =
     Printf.sprintf "[%s]" (String.concat "; " (List.map formula_to_coq formula_list));;


### PR DESCRIPTION
Remove useless parentheses in the Coq export of formulas.
Extend Coq export to open proofs.
