### PR TITLE
Refactoring sequent and formula

### DIFF
--- a/apply_rule.ml
+++ b/apply_rule.ml
@@ -18,7 +18,7 @@ let apply_rule_with_exceptions request_as_json =
     let rule_request_as_json = get_key request_as_json "ruleRequest" in
     let rule_request = Rule_request.from_json rule_request_as_json in
     let sequent_as_json = get_key request_as_json "sequent" in
-    let sequent = Sequent.from_json sequent_as_json in
+    let sequent = Raw_sequent.sequent_from_json sequent_as_json in
     let proof = Proof.from_sequent_and_rule_request sequent rule_request in
     Proof.get_premises proof
 
@@ -27,12 +27,12 @@ let apply_rule request_as_json =
         let sequent_list = List.map Proof.get_conclusion proof_list in
         true, `Assoc [
             ("success", `Bool true);
-            ("sequentList", `List (List.map Sequent.sequent_to_json sequent_list))
+            ("sequentList", `List (List.map Raw_sequent.sequent_to_json sequent_list))
         ]
     with
         | Bad_request_exception m -> false, `String ("Bad request: " ^ m)
         | Rule_request.Json_exception m -> false, `String ("Bad rule json: " ^ m)
-        | Sequent.Json_exception m -> false, `String ("Bad sequent json: " ^ m)
+        | Raw_sequent.Json_exception m -> false, `String ("Bad sequent json: " ^ m)
         | Proof.Technical_exception m -> false, `String m
         | Proof.Pedagogic_exception m ->
             true, `Assoc [("success", `Bool false); ("errorMessage", `String m)]

--- a/export_as_coq.ml
+++ b/export_as_coq.ml
@@ -37,7 +37,7 @@ let export_as_coq request_as_json =
     try let proof_as_coq = export_as_coq_with_exceptions request_as_json in
         true, proof_as_coq
     with Proof.Json_exception m -> false, "Bad proof json: " ^ m
-        | Sequent.Json_exception m -> false, "Bad sequent json: " ^ m
+        | Raw_sequent.Json_exception m -> false, "Bad sequent json: " ^ m
         | Rule_request.Json_exception m -> false, "Bad rule_request json: " ^ m
         | Proof.Technical_exception m -> false, "Invalid proof: " ^ m
         | Cannot_export_proof_as_coq_exception m -> false, "Cannot export proof as coq: " ^ m;;

--- a/export_as_latex.ml
+++ b/export_as_latex.ml
@@ -45,7 +45,7 @@ let export_as_latex request_as_json =
     try let proof_as_latex = export_as_latex_with_exceptions request_as_json in
         true, proof_as_latex
     with Proof.Json_exception m -> false, "Bad proof json: " ^ m
-        | Sequent.Json_exception m -> false, "Bad sequent json: " ^ m
+        | Raw_sequent.Json_exception m -> false, "Bad sequent json: " ^ m
         | Rule_request.Json_exception m -> false, "Bad rule_request json: " ^ m
         | Proof.Technical_exception m -> false, "Invalid proof: " ^ m
         | Cannot_export_proof_as_latex_exception m -> false, "Cannot export proof as LaTeX: " ^ m;;

--- a/is_proof_complete.ml
+++ b/is_proof_complete.ml
@@ -6,6 +6,6 @@ let is_proof_complete request_as_json =
     try let is_complete = check_proof_complete_with_exceptions request_as_json in
         true, `Assoc [("is_complete", `Bool is_complete)]
     with Proof.Json_exception m -> false, `String ("Bad proof json: " ^ m)
-        | Sequent.Json_exception m -> false, `String ("Bad sequent json: " ^ m)
+        | Raw_sequent.Json_exception m -> false, `String ("Bad sequent json: " ^ m)
         | Rule_request.Json_exception m -> false, `String ("Bad rule_request json: " ^ m)
         | Proof.Technical_exception m -> false, `String ("Invalid proof: " ^ m);;

--- a/ll_parser.ml
+++ b/ll_parser.ml
@@ -21,7 +21,7 @@ type token =
 open Parsing;;
 let _ = parse_error;;
 # 2 "ll_parser.mly"
-open Sequent
+open Raw_sequent
 # 26 "ll_parser.ml"
 let yytransl_const = [|
   257 (* THESIS *);
@@ -166,34 +166,34 @@ let yyact = [|
 # 28 "ll_parser.mly"
                                           ( {hyp=[]; cons=[]} )
 # 169 "ll_parser.ml"
-               : Sequent.sequent))
+               : Raw_sequent.raw_sequent))
 ; (fun __caml_parser_env ->
     Obj.repr(
 # 29 "ll_parser.mly"
                                           ( {hyp=[]; cons=[]} )
 # 175 "ll_parser.ml"
-               : Sequent.sequent))
+               : Raw_sequent.raw_sequent))
 ; (fun __caml_parser_env ->
     let _1 = (Parsing.peek_val __caml_parser_env 1 : 'formulalist) in
     Obj.repr(
 # 30 "ll_parser.mly"
                                           ( {hyp=[]; cons=_1} )
 # 182 "ll_parser.ml"
-               : Sequent.sequent))
+               : Raw_sequent.raw_sequent))
 ; (fun __caml_parser_env ->
     let _1 = (Parsing.peek_val __caml_parser_env 2 : 'formulalist) in
     Obj.repr(
 # 31 "ll_parser.mly"
                                           ( {hyp=_1; cons=[]} )
 # 189 "ll_parser.ml"
-               : Sequent.sequent))
+               : Raw_sequent.raw_sequent))
 ; (fun __caml_parser_env ->
     let _2 = (Parsing.peek_val __caml_parser_env 1 : 'formulalist) in
     Obj.repr(
 # 32 "ll_parser.mly"
                                           ( {hyp=[]; cons=_2} )
 # 196 "ll_parser.ml"
-               : Sequent.sequent))
+               : Raw_sequent.raw_sequent))
 ; (fun __caml_parser_env ->
     let _1 = (Parsing.peek_val __caml_parser_env 3 : 'formulalist) in
     let _3 = (Parsing.peek_val __caml_parser_env 1 : 'formulalist) in
@@ -201,7 +201,7 @@ let yyact = [|
 # 33 "ll_parser.mly"
                                           ( {hyp=_1; cons=_3} )
 # 204 "ll_parser.ml"
-               : Sequent.sequent))
+               : Raw_sequent.raw_sequent))
 ; (fun __caml_parser_env ->
     let _1 = (Parsing.peek_val __caml_parser_env 0 : 'formula) in
     Obj.repr(
@@ -337,4 +337,4 @@ let yytables =
     Parsing.names_const=yynames_const;
     Parsing.names_block=yynames_block }
 let main (lexfun : Lexing.lexbuf -> token) (lexbuf : Lexing.lexbuf) =
-   (Parsing.yyparse yytables 1 lexfun lexbuf : Sequent.sequent)
+   (Parsing.yyparse yytables 1 lexfun lexbuf : Raw_sequent.raw_sequent)

--- a/ll_parser.mli
+++ b/ll_parser.mli
@@ -19,4 +19,4 @@ type token =
   | WHYNOT
 
 val main :
-  (Lexing.lexbuf  -> token) -> Lexing.lexbuf -> Sequent.sequent
+  (Lexing.lexbuf  -> token) -> Lexing.lexbuf -> Raw_sequent.raw_sequent

--- a/ll_parser.mly
+++ b/ll_parser.mly
@@ -1,5 +1,5 @@
 %{
-open Sequent
+open Raw_sequent
 %}
 
 %token THESIS
@@ -22,7 +22,7 @@ open Sequent
 %nonassoc ORTH              /* highest precedence */
 
 %start main                 /* the entry point */
-%type <Sequent.sequent> main
+%type <Raw_sequent.raw_sequent> main
 %%
 main:
     EOL                                   { {hyp=[]; cons=[]} }

--- a/parse_sequent.ml
+++ b/parse_sequent.ml
@@ -1,7 +1,7 @@
 let ll_parse sequent_as_string =
-    let sequent = Ll_parser.main Ll_lexer.token (Lexing.from_string sequent_as_string) in
-    let monolatery_sequent = Sequent.get_monolatery_sequent sequent in
-    let sequent_as_json = Sequent.sequent_to_json monolatery_sequent in
+    let raw_sequent = Ll_parser.main Ll_lexer.token (Lexing.from_string sequent_as_string) in
+    let sequent = Raw_sequent.to_sequent raw_sequent in
+    let sequent_as_json = Raw_sequent.sequent_to_json sequent in
     sequent_as_json;;
 
 let safe_parse sequent_as_string =

--- a/proof.ml
+++ b/proof.ml
@@ -22,85 +22,82 @@ let permutation_inverse perm =
 
 (* PROOF *)
 
+
 type proof =
-    | Axiom_left of formula
-    | Axiom_right of formula
-    | One
-    | Top of formula list * formula list
-    | Bottom of formula list * formula list * proof
-    | Tensor of formula list * formula * formula * formula list * proof * proof
-    | Par of formula list * formula * formula * formula list * proof
-    | With of formula list * formula * formula * formula list * proof * proof
-    | Plus_left of formula list * formula * formula * formula list * proof
-    | Plus_right of formula list * formula * formula * formula list * proof
-    | Promotion of formula list * formula * formula list * proof
-    | Dereliction of formula list * formula * formula list * proof
-    | Weakening of formula list * formula * formula list * proof
-    | Contraction of formula list * formula * formula list * proof
-    | Exchange of sequent * int list * proof
-    | Hypothesis of sequent;;
+    | Axiom_proof of formula
+    | One_proof
+    | Top_proof of formula list * formula list
+    | Bottom_proof of formula list * formula list * proof
+    | Tensor_proof of formula list * formula * formula * formula list * proof * proof
+    | Par_proof of formula list * formula * formula * formula list * proof
+    | With_proof of formula list * formula * formula * formula list * proof * proof
+    | Plus_left_proof of formula list * formula * formula * formula list * proof
+    | Plus_right_proof of formula list * formula * formula * formula list * proof
+    | Promotion_proof of formula list * formula * formula list * proof
+    | Dereliction_proof of formula list * formula * formula list * proof
+    | Weakening_proof of formula list * formula * formula list * proof
+    | Contraction_proof of formula list * formula * formula list * proof
+    | Exchange_proof of sequent * int list * proof
+    | Hypothesis_proof of sequent;;
 
 
 (* GETTERS & SETTERS *)
 
 let get_premises = function
-    | Axiom_left _ -> []
-    | Axiom_right _ -> []
-    | One -> []
-    | Top (_, _) -> []
-    | Bottom (_, _, p) -> [p]
-    | Tensor (_, _, _, _, p1, p2) -> [p1; p2]
-    | Par (_, _, _, _, p) -> [p]
-    | With (_, _, _, _, p1, p2) -> [p1; p2]
-    | Plus_left (_, _, _, _, p) -> [p]
-    | Plus_right (_, _, _, _, p) -> [p]
-    | Promotion (_, _, _, p) -> [p]
-    | Dereliction (_, _, _, p) -> [p]
-    | Weakening (_, _, _, p) -> [p]
-    | Contraction (_, _, _, p) -> [p]
-    | Exchange (_, _, p) -> [p]
-    | Hypothesis s -> raise (Failure "Can not get premises of hypothesis");;
+    | Axiom_proof _ -> []
+    | One_proof -> []
+    | Top_proof (_, _) -> []
+    | Bottom_proof (_, _, p) -> [p]
+    | Tensor_proof (_, _, _, _, p1, p2) -> [p1; p2]
+    | Par_proof (_, _, _, _, p) -> [p]
+    | With_proof (_, _, _, _, p1, p2) -> [p1; p2]
+    | Plus_left_proof (_, _, _, _, p) -> [p]
+    | Plus_right_proof (_, _, _, _, p) -> [p]
+    | Promotion_proof (_, _, _, p) -> [p]
+    | Dereliction_proof (_, _, _, p) -> [p]
+    | Weakening_proof (_, _, _, p) -> [p]
+    | Contraction_proof (_, _, _, p) -> [p]
+    | Exchange_proof (_, _, p) -> [p]
+    | Hypothesis_proof s -> raise (Failure "Can not get premises of hypothesis");;
 
 let set_premises proof premises = match proof, premises with
-    | Axiom_left _, [] -> proof
-    | Axiom_right _, [] -> proof
-    | One, [] -> proof
-    | Top (_, _), [] -> proof
-    | Bottom (head, tail, _), [p] -> Bottom (head, tail, p)
-    | Tensor (head, e1, e2, tail, _, _), [p1; p2] -> Tensor (head, e1, e2, tail, p1, p2)
-    | Par (head, e1, e2, tail, _), [p]  -> Par (head, e1, e2, tail, p)
-    | With (head, e1, e2, tail, _, _), [p1; p2] -> With (head, e1, e2, tail, p1, p2)
-    | Plus_left (head, e1, e2, tail, _), [p] -> Plus_left (head, e1, e2, tail, p)
-    | Plus_right (head, e1, e2, tail, _), [p] -> Plus_right (head, e1, e2, tail, p)
-    | Promotion (head_without_whynot, e, tail_without_whynot, _), [p] ->
-        Promotion (head_without_whynot, e, tail_without_whynot, p)
-    | Dereliction (head, e, tail, _), [p] -> Dereliction (head, e, tail, p)
-    | Weakening (head, e, tail, _), [p] -> Weakening (head, e, tail, p)
-    | Contraction (head, e, tail, _), [p] -> Contraction (head, e, tail, p)
-    | Exchange (sequent, permutation, _), [p] -> Exchange (sequent, permutation, p)
-    | Hypothesis sequent, _ -> raise (Failure "Can not set premises of hypothesis")
+    | Axiom_proof _, [] -> proof
+    | One_proof, [] -> proof
+    | Top_proof (_, _), [] -> proof
+    | Bottom_proof (head, tail, _), [p] -> Bottom_proof (head, tail, p)
+    | Tensor_proof (head, e1, e2, tail, _, _), [p1; p2] -> Tensor_proof (head, e1, e2, tail, p1, p2)
+    | Par_proof (head, e1, e2, tail, _), [p]  -> Par_proof (head, e1, e2, tail, p)
+    | With_proof (head, e1, e2, tail, _, _), [p1; p2] -> With_proof (head, e1, e2, tail, p1, p2)
+    | Plus_left_proof (head, e1, e2, tail, _), [p] -> Plus_left_proof (head, e1, e2, tail, p)
+    | Plus_right_proof (head, e1, e2, tail, _), [p] -> Plus_right_proof (head, e1, e2, tail, p)
+    | Promotion_proof (head_without_whynot, e, tail_without_whynot, _), [p] ->
+        Promotion_proof (head_without_whynot, e, tail_without_whynot, p)
+    | Dereliction_proof (head, e, tail, _), [p] -> Dereliction_proof (head, e, tail, p)
+    | Weakening_proof (head, e, tail, _), [p] -> Weakening_proof (head, e, tail, p)
+    | Contraction_proof (head, e, tail, _), [p] -> Contraction_proof (head, e, tail, p)
+    | Exchange_proof (sequent, permutation, _), [p] -> Exchange_proof (sequent, permutation, p)
+    | Hypothesis_proof sequent, _ -> raise (Failure "Can not set premises of hypothesis")
     | _ -> raise (Failure "Number of premises mismatch with given proof");;
 
 let get_conclusion = function
-    | Axiom_left e -> {hyp=[]; cons=[e; orthogonal e]}
-    | Axiom_right e -> {hyp=[]; cons=[orthogonal e; e]}
-    | One -> {hyp=[]; cons=[Sequent.One]}
-    | Top (head, tail) -> {hyp=[]; cons=head @ [Sequent.Top] @ tail}
-    | Bottom (head, tail, _) -> {hyp=[]; cons=head @ [Sequent.Bottom] @ tail}
-    | Tensor (head, e1, e2, tail, _, _) -> {hyp=[]; cons=head @ [Sequent.Tensor (e1, e2)] @ tail}
-    | Par (head, e1, e2, tail, _) -> {hyp=[]; cons=head @ [Sequent.Par (e1, e2)] @ tail}
-    | With (head, e1, e2, tail, _, _) -> {hyp=[]; cons=head @ [Sequent.With (e1, e2)] @ tail}
-    | Plus_left (head, e1, e2, tail, _) -> {hyp=[]; cons=head @ [Plus (e1, e2)] @ tail}
-    | Plus_right (head, e1, e2, tail, _) -> {hyp=[]; cons=head @ [Plus (e1, e2)] @ tail}
-    | Promotion (head_without_whynot, e, tail_without_whynot, _) ->
+    | Axiom_proof e -> [e; orthogonal e]
+    | One_proof -> [Sequent.One]
+    | Top_proof (head, tail) -> head @ [Sequent.Top] @ tail
+    | Bottom_proof (head, tail, _) -> head @ [Sequent.Bottom] @ tail
+    | Tensor_proof (head, e1, e2, tail, _, _) -> head @ [Sequent.Tensor (e1, e2)] @ tail
+    | Par_proof (head, e1, e2, tail, _) -> head @ [Sequent.Par (e1, e2)] @ tail
+    | With_proof (head, e1, e2, tail, _, _) -> head @ [Sequent.With (e1, e2)] @ tail
+    | Plus_left_proof (head, e1, e2, tail, _) -> head @ [Plus (e1, e2)] @ tail
+    | Plus_right_proof (head, e1, e2, tail, _) -> head @ [Plus (e1, e2)] @ tail
+    | Promotion_proof (head_without_whynot, e, tail_without_whynot, _) ->
         let head = Sequent.add_whynot head_without_whynot in
         let tail = Sequent.add_whynot tail_without_whynot in
-        {hyp=[]; cons=head @ [Ofcourse e] @ tail}
-    | Dereliction (head, e, tail, _) -> {hyp=[]; cons=head @ [Whynot e] @ tail}
-    | Weakening (head, e, tail, _) -> {hyp=[]; cons=head @ [Whynot e] @ tail}
-    | Contraction (head, e, tail, _) -> {hyp=[]; cons=head @ [Whynot e] @ tail}
-    | Exchange (sequent, permutation, _) -> {hyp=[]; cons=permute sequent.cons permutation}
-    | Hypothesis sequent -> sequent;;
+        head @ [Ofcourse e] @ tail
+    | Dereliction_proof (head, e, tail, _) -> head @ [Whynot e] @ tail
+    | Weakening_proof (head, e, tail, _) -> head @ [Whynot e] @ tail
+    | Contraction_proof (head, e, tail, _) -> head @ [Whynot e] @ tail
+    | Exchange_proof (sequent, permutation, _) -> permute sequent permutation
+    | Hypothesis_proof sequent -> sequent;;
 
 
 (* SEQUENT & RULE_REQUEST -> PROOF *)
@@ -116,98 +113,96 @@ let rec head_formula_tail n = function
 
 let from_sequent_and_rule_request sequent rule_request =
     match rule_request with
-        Axiom -> (
-            match sequent.cons with
-            | e1 :: e2 :: [] -> if orthogonal e1 <> e2
+        | Axiom -> (
+            match sequent with
+            | e1 :: e2 :: [] -> (if orthogonal e1 <> e2
                 then raise (Pedagogic_exception ("Can not apply 'axiom' rule: the two formulas are not orthogonal."))
-                else (match e2 with
-                | Orth e -> Axiom_left e
-                | _ -> Axiom_right e2)
+                else Axiom_proof e1)
             | _ -> raise (Pedagogic_exception ("Can not apply 'axiom' rule: the sequent must contain exactly two formulas."))
         )
         | One -> (
-            match sequent.cons with
-            | One :: [] -> One
+            match sequent with
+            | One :: [] -> One_proof
             | _ -> raise (Pedagogic_exception ("Can not apply 'one' rule: the sequent must be reduced to the single formula '1'."))
         )
         | Bottom n -> (
-            let head, formula, tail = head_formula_tail n sequent.cons in
+            let head, formula, tail = head_formula_tail n sequent in
             match formula with
-            | Bottom -> Bottom (head, tail, (Hypothesis {hyp=[]; cons=(head @ tail)}))
+            | Bottom -> Bottom_proof (head, tail, (Hypothesis_proof (head @ tail)))
             | _ -> raise (Technical_exception ("Cannot apply bottom rule on this formula"))
         )
         | Top n -> (
-            let head, formula, tail = head_formula_tail n sequent.cons in
+            let head, formula, tail = head_formula_tail n sequent in
             match formula with
-            | Top -> Top (head, tail)
+            | Top -> Top_proof (head, tail)
             | _ -> raise (Technical_exception ("Cannot apply top rule on this formula"))
         )
         | Zero n -> raise (Pedagogic_exception ("Can not apply 'zero' rule: there is no rule for introducing '0'."))
         | Tensor n -> (
-            let head, formula, tail = head_formula_tail n sequent.cons in
+            let head, formula, tail = head_formula_tail n sequent in
             match formula with
-            Tensor (e1, e2) -> Tensor (head, e1, e2, tail, (Hypothesis {hyp=[]; cons=(head @ [e1])}), (Hypothesis {hyp=[]; cons=([e2] @ tail)}))
+            Tensor (e1, e2) -> Tensor_proof (head, e1, e2, tail, (Hypothesis_proof (head @ [e1])), (Hypothesis_proof ([e2] @ tail)))
             | _ -> raise (Technical_exception ("Cannot apply tensor rule on this formula"))
         )
         | Par n -> (
-            let head, formula, tail = head_formula_tail n sequent.cons in
+            let head, formula, tail = head_formula_tail n sequent in
             match formula with
-            Par (e1, e2) -> Par (head, e1, e2, tail, (Hypothesis {hyp=[]; cons=(head @ [e1; e2] @ tail)}))
+            Par (e1, e2) -> Par_proof (head, e1, e2, tail, (Hypothesis_proof (head @ [e1; e2] @ tail)))
             | _ -> raise (Technical_exception ("Cannot apply par rule on this formula"))
         )
         | With n -> (
-            let head, formula, tail = head_formula_tail n sequent.cons in
+            let head, formula, tail = head_formula_tail n sequent in
             match formula with
-            With (e1, e2) -> With (head, e1, e2, tail, (Hypothesis {hyp=[]; cons=(head @ [e1] @ tail)}), (Hypothesis {hyp=[]; cons=(head @ [e2] @ tail)}))
+            With (e1, e2) -> With_proof (head, e1, e2, tail, (Hypothesis_proof (head @ [e1] @ tail)), (Hypothesis_proof (head @ [e2] @ tail)))
             | _ -> raise (Technical_exception ("Cannot apply with rule on this formula"))
         )
         | Plus_left n -> (
-            let head, formula, tail = head_formula_tail n sequent.cons in
+            let head, formula, tail = head_formula_tail n sequent in
             match formula with
-            Plus (e1, e2) -> Plus_left (head, e1, e2, tail, (Hypothesis {hyp=[]; cons=(head @ [e1] @ tail)}))
+            Plus (e1, e2) -> Plus_left_proof (head, e1, e2, tail, (Hypothesis_proof (head @ [e1] @ tail)))
             | _ -> raise (Technical_exception ("Cannot apply plus_left rule on this formula"))
         )
         | Plus_right n -> (
-            let head, formula, tail = head_formula_tail n sequent.cons in
+            let head, formula, tail = head_formula_tail n sequent in
             match formula with
-            Plus (e1, e2) -> Plus_right (head, e1, e2, tail, (Hypothesis {hyp=[]; cons=(head @ [e2] @ tail)}))
+            Plus (e1, e2) -> Plus_right_proof (head, e1, e2, tail, (Hypothesis_proof (head @ [e2] @ tail)))
             | _ -> raise (Technical_exception ("Cannot apply plus_right rule on this formula"))
         )
         | Promotion n -> (
-            let head, formula, tail = head_formula_tail n sequent.cons in
+            let head, formula, tail = head_formula_tail n sequent in
             match formula with
             Ofcourse e -> (try
                 let head_without_whynot = Sequent.remove_whynot head in
                 let tail_without_whynot = remove_whynot tail in
-                Promotion (head_without_whynot, e, tail_without_whynot, (Hypothesis {hyp=[]; cons=(head @ [e] @ tail)}))
+                Promotion_proof (head_without_whynot, e, tail_without_whynot, (Hypothesis_proof (head @ [e] @ tail)))
                 with Sequent.Not_whynot -> raise (Pedagogic_exception ("Can not apply 'promotion' rule: the context must contain formulas starting by '?' only.")))
             | _ -> raise (Technical_exception ("Cannot apply promotion rule on this formula"))
         )
         | Dereliction n -> (
-            let head, formula, tail = head_formula_tail n sequent.cons in
+            let head, formula, tail = head_formula_tail n sequent in
             match formula with
-            Whynot e -> Dereliction (head, e, tail, (Hypothesis {hyp=[]; cons=(head @ [e] @ tail)}))
+            Whynot e -> Dereliction_proof (head, e, tail, (Hypothesis_proof (head @ [e] @ tail)))
             | _ -> raise (Technical_exception ("Cannot apply dereliction rule on this formula"))
         )
         | Weakening n -> (
-            let head, formula, tail = head_formula_tail n sequent.cons in
+            let head, formula, tail = head_formula_tail n sequent in
             match formula with
-            Whynot e -> Weakening (head, e, tail, (Hypothesis {hyp=[]; cons=(head @ tail)}))
+            Whynot e -> Weakening_proof (head, e, tail, (Hypothesis_proof (head @ tail)))
             | _ -> raise (Technical_exception ("Cannot apply weakening rule on this formula"))
         )
         | Contraction n -> (
-            let head, formula, tail = head_formula_tail n sequent.cons in
+            let head, formula, tail = head_formula_tail n sequent in
             match formula with
-            Whynot e -> Contraction (head, e, tail, (Hypothesis {hyp=[]; cons=(head @ [Whynot e; Whynot e] @ tail)}))
+            Whynot e -> Contraction_proof (head, e, tail, (Hypothesis_proof (head @ [Whynot e; Whynot e] @ tail)))
             | _ -> raise (Technical_exception ("Cannot apply contraction rule on this formula"))
         )
         | Exchange permutation -> (
-            if List.length sequent.cons <> List.length permutation
+            if List.length sequent <> List.length permutation
             then raise (Technical_exception ("When applying exchange rule, formula_positions and sequent must have same size"))
             else if not (is_valid_permutation permutation)
             then raise (Technical_exception ("When applying exchange rule, formula_positions should be a permutation of the size of sequent formula list"))
-            else let permuted_sequent = {hyp=[]; cons=permute sequent.cons permutation} in
-            Exchange (permuted_sequent, permutation_inverse permutation, (Hypothesis permuted_sequent))
+            else let permuted_sequent = permute sequent permutation in
+            Exchange_proof (permuted_sequent, permutation_inverse permutation, (Hypothesis_proof permuted_sequent))
         );;
 
 let from_sequent_and_rule_request_and_premises sequent rule_request premises =
@@ -243,10 +238,10 @@ let get_json_list json key =
 
 let rec from_json json =
     let sequent_as_json = required_field json "sequentAsJson" in
-    let sequent = Sequent.from_json sequent_as_json in
+    let sequent = Raw_sequent.sequent_from_json sequent_as_json in
     let applied_ruled_as_json = optional_field json "appliedRule" in
     match applied_ruled_as_json with
-        | `Null -> Hypothesis sequent
+        | `Null -> Hypothesis_proof sequent
         | _ -> let rule_request_as_json = required_field applied_ruled_as_json "ruleRequest" in
             let rule_request = Rule_request.from_json rule_request_as_json in
             let premises_as_json = get_json_list applied_ruled_as_json "premises" in
@@ -257,7 +252,7 @@ let rec from_json json =
 (* OPERATIONS *)
 
 let rec is_complete = function
-    | Hypothesis s -> false
+    | Hypothesis_proof s -> false
     | proof -> let premises = get_premises proof in
         List.for_all is_complete premises;;
 
@@ -285,46 +280,45 @@ let add_indent_and_brace proof_as_coq =
     in Printf.sprintf "{ %s }\n" (String.concat "\n" indented_lines)
 
 let rec to_coq_with_hyps_increment i = function
-    | Axiom_left _ -> "ax_expansion.\n", i, []
-    | Axiom_right _ -> "ax_expansion.\n", i, []
-    | One -> coq_apply "one_r_ext", i, []
-    | Top (head, _) -> coq_apply_with_args "top_r_ext" [formula_list_to_coq head], i, []
-    | Bottom (head, _, p) ->
+    | Axiom_proof _ -> "ax_expansion.\n", i, []
+    | One_proof -> coq_apply "one_r_ext", i, []
+    | Top_proof (head, _) -> coq_apply_with_args "top_r_ext" [formula_list_to_coq head], i, []
+    | Bottom_proof (head, _, p) ->
         let s, n, hyps = to_coq_with_hyps_increment i p in
         coq_apply_with_args "bot_r_ext" [formula_list_to_coq head] ^ s, n, hyps
-    | Tensor (head, _, _, _, p1, p2) -> 
+    | Tensor_proof (head, _, _, _, p1, p2) ->
         let s1, n1, hyps1 = to_coq_with_hyps_increment i p1 in
         let s2, n2, hyps2 = to_coq_with_hyps_increment n1 p2 in
         coq_apply_with_args "tens_r_ext" [formula_list_to_coq head] ^ add_indent_and_brace s1 ^ add_indent_and_brace s2, n2, hyps1 @ hyps2
-    | Par (head, _, _, _, p) ->
+    | Par_proof (head, _, _, _, p) ->
         let s, n, hyps = to_coq_with_hyps_increment i p in
         coq_apply_with_args "parr_r_ext" [formula_list_to_coq head] ^ s, n, hyps
-    | With (head, _, _, _, p1, p2) ->
+    | With_proof (head, _, _, _, p1, p2) ->
         let s1, n1, hyps1 = to_coq_with_hyps_increment i p1 in
         let s2, n2, hyps2 = to_coq_with_hyps_increment n1 p2 in
         coq_apply_with_args "with_r_ext" [formula_list_to_coq head] ^ add_indent_and_brace s1 ^ add_indent_and_brace s2, n2, hyps1 @ hyps2
-    | Plus_left (head, _, _, _, p) ->
+    | Plus_left_proof (head, _, _, _, p) ->
         let s, n, hyps = to_coq_with_hyps_increment i p in
         coq_apply_with_args "plus_r1_ext" [formula_list_to_coq head] ^ s, n, hyps
-    | Plus_right (head, _, _, _, p) ->
+    | Plus_right_proof (head, _, _, _, p) ->
         let s, n, hyps = to_coq_with_hyps_increment i p in
         coq_apply_with_args "plus_r2_ext" [formula_list_to_coq head] ^ s, n, hyps
-    | Promotion (head_without_whynot, e, tail_without_whynot, p) ->
+    | Promotion_proof (head_without_whynot, e, tail_without_whynot, p) ->
         let s, n, hyps = to_coq_with_hyps_increment i p in
         coq_apply_with_args "oc_r_ext" [formula_list_to_coq head_without_whynot; "(" ^ formula_to_coq e ^ ")"; formula_list_to_coq tail_without_whynot] ^ s, n, hyps
-    | Dereliction (head, _, _, p) ->
+    | Dereliction_proof (head, _, _, p) ->
         let s, n, hyps = to_coq_with_hyps_increment i p in
         coq_apply_with_args "de_r_ext" [formula_list_to_coq head] ^ s, n, hyps
-    | Weakening (head, _, _, p) ->
+    | Weakening_proof (head, _, _, p) ->
         let s, n, hyps = to_coq_with_hyps_increment i p in
         coq_apply_with_args "wk_r_ext" [formula_list_to_coq head] ^ s, n, hyps
-    | Contraction (head, _, _, p) ->
+    | Contraction_proof (head, _, _, p) ->
         let s, n, hyps = to_coq_with_hyps_increment i p in
         coq_apply_with_args "co_r_ext" [formula_list_to_coq head] ^ s, n, hyps
-    | Exchange (sequent, permutation, p) ->
+    | Exchange_proof (sequent, permutation, p) ->
         let s, n, hyps = to_coq_with_hyps_increment i p in
-        coq_apply_with_args "ex_perm_r" [permutation_to_coq permutation; formula_list_to_coq sequent.cons] ^ s, n, hyps
-    | Hypothesis sequent -> coq_apply ("Hyp" ^ string_of_int i), i + 1, [Sequent.sequent_to_coq sequent];;
+        coq_apply_with_args "ex_perm_r" [permutation_to_coq permutation; formula_list_to_coq sequent] ^ s, n, hyps
+    | Hypothesis_proof sequent -> coq_apply ("Hyp" ^ string_of_int i), i + 1, [Sequent.sequent_to_coq sequent];;
 
 let to_coq_with_hyps = to_coq_with_hyps_increment 0
 
@@ -335,19 +329,18 @@ let latex_apply latex_rule conclusion =
 let rec to_latex proof =
     let conclusion = sequent_to_latex (get_conclusion proof) in
     match proof with
-    | Axiom_left _ -> latex_apply "axv" conclusion
-    | Axiom_right _ -> latex_apply "axv" conclusion
-    | One -> latex_apply "onev" conclusion
-    | Top _ -> latex_apply "topv" conclusion
-    | Bottom (_, _, p) -> to_latex p ^ (latex_apply "botv" conclusion)
-    | Tensor (_, _, _, _, p1, p2) -> to_latex p1 ^ (to_latex p2) ^ (latex_apply "tensorv" conclusion)
-    | Par (_, _, _, _, p) -> to_latex p ^ (latex_apply "parrv" conclusion)
-    | With (_, _, _, _, p1, p2) -> to_latex p1 ^ (to_latex p2) ^ (latex_apply "withv" conclusion)
-    | Plus_left (_, _, _, _, p) -> to_latex p ^ (latex_apply "pluslv" conclusion)
-    | Plus_right (_, _, _, _, p) -> to_latex p ^ (latex_apply "plusrv" conclusion)
-    | Promotion (_, _, _, p) -> to_latex p ^ (latex_apply "ocv" conclusion)
-    | Dereliction (_, _, _, p) -> to_latex p ^ (latex_apply "dev" conclusion)
-    | Weakening (_, _, _, p) -> to_latex p ^ (latex_apply "wkv" conclusion)
-    | Contraction (_, _, _, p) -> to_latex p ^ (latex_apply "cov" conclusion)
-    | Exchange (_, _, p) -> to_latex p ^ (latex_apply "exv" conclusion)
-    | Hypothesis _ -> latex_apply "hypv" conclusion;;
+    | Axiom_proof _ -> latex_apply "axv" conclusion
+    | One_proof -> latex_apply "onev" conclusion
+    | Top_proof _ -> latex_apply "topv" conclusion
+    | Bottom_proof (_, _, p) -> to_latex p ^ (latex_apply "botv" conclusion)
+    | Tensor_proof (_, _, _, _, p1, p2) -> to_latex p1 ^ (to_latex p2) ^ (latex_apply "tensorv" conclusion)
+    | Par_proof (_, _, _, _, p) -> to_latex p ^ (latex_apply "parrv" conclusion)
+    | With_proof (_, _, _, _, p1, p2) -> to_latex p1 ^ (to_latex p2) ^ (latex_apply "withv" conclusion)
+    | Plus_left_proof (_, _, _, _, p) -> to_latex p ^ (latex_apply "pluslv" conclusion)
+    | Plus_right_proof (_, _, _, _, p) -> to_latex p ^ (latex_apply "plusrv" conclusion)
+    | Promotion_proof (_, _, _, p) -> to_latex p ^ (latex_apply "ocv" conclusion)
+    | Dereliction_proof (_, _, _, p) -> to_latex p ^ (latex_apply "dev" conclusion)
+    | Weakening_proof (_, _, _, p) -> to_latex p ^ (latex_apply "wkv" conclusion)
+    | Contraction_proof (_, _, _, p) -> to_latex p ^ (latex_apply "cov" conclusion)
+    | Exchange_proof (_, _, p) -> to_latex p ^ (latex_apply "exv" conclusion)
+    | Hypothesis_proof _ -> latex_apply "hypv" conclusion;;

--- a/raw_sequent.ml
+++ b/raw_sequent.ml
@@ -1,0 +1,144 @@
+open Sequent
+
+(* DEFINITION *)
+
+type raw_formula =
+  | One
+  | Bottom
+  | Top
+  | Zero
+  | Litt of string
+  | Orth of raw_formula
+  | Tensor of raw_formula * raw_formula
+  | Par of raw_formula * raw_formula
+  | With of raw_formula * raw_formula
+  | Plus of raw_formula * raw_formula
+  | Lollipop of raw_formula * raw_formula
+  | Ofcourse of raw_formula
+  | Whynot of raw_formula;;
+
+type raw_sequent = {hyp: raw_formula list; cons: raw_formula list};;
+
+
+(* RAW_SEQUENT -> SEQUENT *)
+
+let rec to_formula raw_formula = match raw_formula with
+    | One -> Sequent.One
+    | Bottom -> Sequent.Bottom
+    | Top -> Sequent.Top
+    | Zero -> Sequent.Zero
+    | Litt x -> Sequent.Litt x
+    | Orth e -> orthogonal (to_formula e)
+    | Tensor (e1, e2) -> Sequent.Tensor (to_formula e1, to_formula e2)
+    | Par (e1, e2) -> Sequent.Par (to_formula e1, to_formula e2)
+    | With (e1, e2) -> Sequent.With (to_formula e1, to_formula e2)
+    | Plus (e1, e2) -> Sequent.Plus (to_formula e1, to_formula e2)
+    | Lollipop (e1, e2) -> Sequent.Par (to_formula (Orth e1), to_formula e2)
+    | Ofcourse e -> Sequent.Ofcourse (to_formula e)
+    | Whynot e -> Sequent.Whynot (to_formula e);;
+
+let to_sequent raw_sequent =
+    List.map to_formula raw_sequent.cons @ List.map orthogonal (List.map to_formula raw_sequent.hyp);;
+
+
+(* SEQUENT -> RAW_SEQUENT *)
+
+let rec to_raw_formula =
+    function
+    | Sequent.One -> One
+    | Sequent.Bottom -> Bottom
+    | Sequent.Top -> Top
+    | Sequent.Zero -> Zero
+    | Sequent.Litt x -> Litt x
+    | Sequent.Orth x -> Orth (Litt x)
+    | Sequent.Tensor (e1, e2) -> Tensor (to_raw_formula e1, to_raw_formula e2)
+    | Sequent.Par (e1, e2) -> Par (to_raw_formula e1, to_raw_formula e2)
+    | Sequent.With (e1, e2) -> With (to_raw_formula e1, to_raw_formula e2)
+    | Sequent.Plus (e1, e2) -> Plus (to_raw_formula e1, to_raw_formula e2)
+    | Sequent.Ofcourse e -> Ofcourse (to_raw_formula e)
+    | Sequent.Whynot e -> Whynot (to_raw_formula e);;
+
+let to_raw_sequent sequent =
+    {hyp=[]; cons=List.map to_raw_formula sequent};;
+
+(* RAW_SEQUENT -> JSON *)
+
+let rec raw_formula_to_json =
+  function
+  | One -> `Assoc ([("type", `String "neutral") ; ("value", `String "one")])
+  | Bottom -> `Assoc ([("type", `String "neutral") ; ("value", `String "bottom")])
+  | Top -> `Assoc ([("type", `String "neutral") ; ("value", `String "top")])
+  | Zero -> `Assoc ([("type", `String "neutral") ; ("value", `String "zero")])
+  | Litt x -> `Assoc ([("type", `String "litteral") ; ("value", `String x)])
+  | Orth e -> `Assoc ([("type", `String "orthogonal") ; ("value", raw_formula_to_json e)])
+  | Tensor (e1, e2) -> `Assoc ([("type", `String "tensor") ; ("value1", raw_formula_to_json e1) ; ("value2", raw_formula_to_json e2)])
+  | Par (e1, e2) -> `Assoc ([("type", `String "par") ; ("value1", raw_formula_to_json e1) ; ("value2", raw_formula_to_json e2)])
+  | With (e1, e2) -> `Assoc ([("type", `String "with") ; ("value1", raw_formula_to_json e1) ; ("value2", raw_formula_to_json e2)])
+  | Plus (e1, e2) -> `Assoc ([("type", `String "plus") ; ("value1", raw_formula_to_json e1) ; ("value2", raw_formula_to_json e2)])
+  | Lollipop (e1, e2) -> `Assoc ([("type", `String "lollipop") ; ("value1", raw_formula_to_json e1) ; ("value2", raw_formula_to_json e2)])
+  | Ofcourse e -> `Assoc ([("type", `String "ofcourse") ; ("value", raw_formula_to_json e)])
+  | Whynot e -> `Assoc ([("type", `String "whynot") ; ("value", raw_formula_to_json e)]);;
+
+let to_json sequent = `Assoc [
+        ("hyp", `List (List.map raw_formula_to_json sequent.hyp));
+        ("cons", `List (List.map raw_formula_to_json sequent.cons))
+    ];;
+
+
+(* JSON -> RAW_SEQUENT *)
+
+exception Json_exception of string;;
+
+let required_field json key =
+    let value =
+        try Yojson.Basic.Util.member key json
+        with Yojson.Basic.Util.Type_error (_, _) -> raise (Json_exception ("a sequent and a formula (or sub-formula) must be a json object"))
+    in
+    if value = `Null
+    then raise (Json_exception ("required field '" ^ key ^ "' is missing"))
+    else value
+
+let get_json_string json key =
+    let value = required_field json key in
+    try Yojson.Basic.Util.to_string value
+    with Yojson.Basic.Util.Type_error (_, _) -> raise (Json_exception ("field '" ^ key ^ "' must be a string"))
+
+let get_json_list json key =
+    let value = required_field json key in
+    try Yojson.Basic.Util.to_list value
+    with Yojson.Basic.Util.Type_error (_, _) -> raise (Json_exception ("field '" ^ key ^ "' must be a list"))
+
+let rec json_to_raw_formula json =
+  let formula_type = get_json_string json "type" in
+  match formula_type with
+  "neutral" -> ( let neutral_value = get_json_string json "value" in
+     match neutral_value with
+       "one" -> One
+       | "bottom" -> Bottom
+       | "top" -> Top
+       | "zero" -> Zero
+       | _ -> raise (Json_exception ("unknown neutral value " ^ neutral_value)) )
+  | "litteral" -> Litt (get_json_string json "value")
+  | "orthogonal" -> Orth (json_to_raw_formula (required_field json "value"))
+  | "tensor" -> Tensor ( json_to_raw_formula (required_field json "value1") , json_to_raw_formula (required_field json "value2"))
+  | "par" -> Par ( json_to_raw_formula (required_field json "value1") , json_to_raw_formula (required_field json "value2"))
+  | "with" -> With ( json_to_raw_formula (required_field json "value1") , json_to_raw_formula (required_field json "value2"))
+  | "plus" -> Plus ( json_to_raw_formula (required_field json "value1") , json_to_raw_formula (required_field json "value2"))
+  | "lollipop" -> Lollipop ( json_to_raw_formula (required_field json "value1") , json_to_raw_formula (required_field json "value2"))
+  | "ofcourse" -> Ofcourse (json_to_raw_formula (required_field json "value"))
+  | "whynot" -> Whynot (json_to_raw_formula (required_field json "value"))
+  | _ -> raise (Json_exception ("unknown formula type " ^ formula_type));;
+
+let from_json sequent_as_json =
+    let hyp_formulas = List.map json_to_raw_formula (get_json_list sequent_as_json "hyp") in
+    let cons_formulas = List.map json_to_raw_formula (get_json_list sequent_as_json "cons") in
+    {hyp=hyp_formulas; cons=cons_formulas}
+
+
+(* SEQUENT <-> JSON *)
+
+let sequent_from_json raw_sequent_as_json =
+    to_sequent (from_json raw_sequent_as_json);;
+
+let sequent_to_json sequent =
+     to_json (to_raw_sequent sequent);;

--- a/raw_sequent.ml
+++ b/raw_sequent.ml
@@ -38,7 +38,7 @@ let rec to_formula raw_formula = match raw_formula with
     | Whynot e -> Sequent.Whynot (to_formula e);;
 
 let to_sequent raw_sequent =
-    List.map to_formula raw_sequent.cons @ List.map orthogonal (List.map to_formula raw_sequent.hyp);;
+    List.map orthogonal (List.map to_formula raw_sequent.hyp) @ List.map to_formula raw_sequent.cons;;
 
 
 (* SEQUENT -> RAW_SEQUENT *)

--- a/sequent.ml
+++ b/sequent.ml
@@ -6,89 +6,62 @@ type formula =
   | Top
   | Zero
   | Litt of string
-  | Orth of formula
+  | Orth of string
   | Tensor of formula * formula
   | Par of formula * formula
   | With of formula * formula
   | Plus of formula * formula
-  | Lollipop of formula * formula
   | Ofcourse of formula
   | Whynot of formula;;
 
-type sequent = {hyp: formula list; cons: formula list};;
-
-(* SEQUENT -> JSON *)
-
-let rec formula_to_json =
-  function
-  | One -> `Assoc ([("type", `String "neutral") ; ("value", `String "one")])
-  | Bottom -> `Assoc ([("type", `String "neutral") ; ("value", `String "bottom")])
-  | Top -> `Assoc ([("type", `String "neutral") ; ("value", `String "top")])
-  | Zero -> `Assoc ([("type", `String "neutral") ; ("value", `String "zero")])
-  | Litt x -> `Assoc ([("type", `String "litteral") ; ("value", `String x)])
-  | Orth e -> `Assoc ([("type", `String "orthogonal") ; ("value", formula_to_json e)])
-  | Tensor (e1, e2) -> `Assoc ([("type", `String "tensor") ; ("value1", formula_to_json e1) ; ("value2", formula_to_json e2)])
-  | Par (e1, e2) -> `Assoc ([("type", `String "par") ; ("value1", formula_to_json e1) ; ("value2", formula_to_json e2)])
-  | With (e1, e2) -> `Assoc ([("type", `String "with") ; ("value1", formula_to_json e1) ; ("value2", formula_to_json e2)])
-  | Plus (e1, e2) -> `Assoc ([("type", `String "plus") ; ("value1", formula_to_json e1) ; ("value2", formula_to_json e2)])
-  | Lollipop (e1, e2) -> `Assoc ([("type", `String "lollipop") ; ("value1", formula_to_json e1) ; ("value2", formula_to_json e2)])
-  | Ofcourse e -> `Assoc ([("type", `String "ofcourse") ; ("value", formula_to_json e)])
-  | Whynot e -> `Assoc ([("type", `String "whynot") ; ("value", formula_to_json e)]);;
-
-let sequent_to_json sequent = `Assoc [
-        ("hyp", `List (List.map formula_to_json sequent.hyp));
-        ("cons", `List (List.map formula_to_json sequent.cons))
-    ];;
+type sequent = formula list;;
 
 
-(* JSON -> SEQUENT *)
+(* OPERATIONS *)
 
-exception Json_exception of string;;
+let rec orthogonal =
+    function
+    | One -> Bottom
+    | Bottom -> One
+    | Top -> Zero
+    | Zero -> Top
+    | Litt x -> Orth x
+    | Orth x -> Litt x
+    | Tensor (e1, e2) -> Par (orthogonal e1, orthogonal e2)
+    | Par (e1, e2) -> Tensor (orthogonal e1, orthogonal e2)
+    | With (e1, e2) -> Plus (orthogonal e1, orthogonal e2)
+    | Plus (e1, e2) -> With (orthogonal e1, orthogonal e2)
+    | Ofcourse e -> Whynot (orthogonal e)
+    | Whynot e -> Ofcourse (orthogonal e);;
 
-let required_field json key =
-    let value =
-        try Yojson.Basic.Util.member key json
-        with Yojson.Basic.Util.Type_error (_, _) -> raise (Json_exception ("a sequent and a formula (or sub-formula) must be a json object"))
-    in
-    if value = `Null
-    then raise (Json_exception ("required field '" ^ key ^ "' is missing"))
-    else value
+exception Not_whynot;;
 
-let get_json_string json key =
-    let value = required_field json key in
-    try Yojson.Basic.Util.to_string value
-    with Yojson.Basic.Util.Type_error (_, _) -> raise (Json_exception ("field '" ^ key ^ "' must be a string"))
+let rec remove_whynot = function
+    | [] -> []
+    | Whynot e :: l -> e :: remove_whynot l
+    | _ -> raise Not_whynot;;
 
-let get_json_list json key =
-    let value = required_field json key in
-    try Yojson.Basic.Util.to_list value
-    with Yojson.Basic.Util.Type_error (_, _) -> raise (Json_exception ("field '" ^ key ^ "' must be a list"))
+let rec add_whynot = function
+    | [] -> []
+    | e :: l -> Whynot e :: add_whynot l;;
 
-let rec json_to_formula json =
-  let formula_type = get_json_string json "type" in
-  match formula_type with
-  "neutral" -> ( let neutral_value = get_json_string json "value" in
-     match neutral_value with
-       "one" -> One
-       | "bottom" -> Bottom
-       | "top" -> Top
-       | "zero" -> Zero
-       | _ -> raise (Json_exception ("unknown neutral value " ^ neutral_value)) )
-  | "litteral" -> Litt (get_json_string json "value")
-  | "orthogonal" -> Orth (json_to_formula (required_field json "value"))
-  | "tensor" -> Tensor ( json_to_formula (required_field json "value1") , json_to_formula (required_field json "value2"))
-  | "par" -> Par ( json_to_formula (required_field json "value1") , json_to_formula (required_field json "value2"))
-  | "with" -> With ( json_to_formula (required_field json "value1") , json_to_formula (required_field json "value2"))
-  | "plus" -> Plus ( json_to_formula (required_field json "value1") , json_to_formula (required_field json "value2"))
-  | "lollipop" -> Lollipop ( json_to_formula (required_field json "value1") , json_to_formula (required_field json "value2"))
-  | "ofcourse" -> Ofcourse (json_to_formula (required_field json "value"))
-  | "whynot" -> Whynot (json_to_formula (required_field json "value"))
-  | _ -> raise (Json_exception ("unknown formula type " ^ formula_type));;
+let rec get_variable_names =
+    function
+    | One -> []
+    | Bottom -> []
+    | Top -> []
+    | Zero -> []
+    | Litt x -> [x]
+    | Orth x -> [x]
+    | Tensor (e1, e2) -> get_variable_names e1 @ get_variable_names e2
+    | Par (e1, e2) -> get_variable_names e1 @ get_variable_names e2
+    | With (e1, e2) -> get_variable_names e1 @ get_variable_names e2
+    | Plus (e1, e2) -> get_variable_names e1 @ get_variable_names e2
+    | Ofcourse e -> get_variable_names e
+    | Whynot e -> get_variable_names e;;
 
-let from_json sequent_as_json =
-    let hyp_formulas = List.map json_to_formula (get_json_list sequent_as_json "hyp") in
-    let cons_formulas = List.map json_to_formula (get_json_list sequent_as_json "cons") in
-    {hyp=hyp_formulas; cons=cons_formulas}
+let get_unique_variable_names sequent =
+    List.sort_uniq String.compare (List.concat (List.map get_variable_names sequent))
 
 
 (* SEQUENT -> COQ *)
@@ -100,10 +73,7 @@ let rec formula_to_coq_atomic =
   | Top -> "top", true
   | Zero -> "zero", true
   | Litt x -> x, true
-  | Orth e ->
-      let s, atomic = formula_to_coq_atomic e in
-      let s_parenthesis = if atomic then s else "(" ^ s ^ ")" in
-      Printf.sprintf "dual %s" s_parenthesis, false
+  | Orth x -> Printf.sprintf "dual %s" x, false
   | Tensor (e1, e2) ->
       let s1, atomic1 = formula_to_coq_atomic e1 in
       let s1_parenthesis = if atomic1 then s1 else "(" ^ s1 ^ ")" in
@@ -128,7 +98,6 @@ let rec formula_to_coq_atomic =
       let s2, atomic2 = formula_to_coq_atomic e2 in
       let s2_parenthesis = if atomic2 then s2 else "(" ^ s2 ^ ")" in
       Printf.sprintf "aplus %s %s" s1_parenthesis s2_parenthesis, false
-  | Lollipop (e1, e2) -> formula_to_coq_atomic (Par (Orth e1, e2))
   | Ofcourse e ->
       let s, atomic = formula_to_coq_atomic e in
       let s_parenthesis = if atomic then s else "(" ^ s ^ ")" in
@@ -145,7 +114,7 @@ let formula_list_to_coq formula_list =
     Printf.sprintf "[%s]" (String.concat "; " (List.map formula_to_coq formula_list));;
 
 let sequent_to_coq sequent =
-    Printf.sprintf "ll %s" (formula_list_to_coq sequent.cons)
+    Printf.sprintf "ll %s" (formula_list_to_coq sequent);;
 
 
 (* SEQUENT -> LATEX *)
@@ -161,10 +130,7 @@ let rec formula_to_latex_atomic =
   | Top -> "\\top", true
   | Zero -> "\\zero", true
   | Litt x -> litteral_to_latex x, true
-  | Orth e ->
-      let s, atomic = formula_to_latex_atomic e in
-      let s_parenthesis = if atomic then "{" ^ s ^ "}" else "(" ^ s ^ ")" in
-      Printf.sprintf "%s\\orth" s_parenthesis, true
+  | Orth x -> Printf.sprintf "%s\\orth" x, true
   | Tensor (e1, e2) ->
       let s1, atomic1 = formula_to_latex_atomic e1 in
       let s1_parenthesis = if atomic1 then s1 else "(" ^ s1 ^ ")" in
@@ -189,7 +155,6 @@ let rec formula_to_latex_atomic =
       let s2, atomic2 = formula_to_latex_atomic e2 in
       let s2_parenthesis = if atomic2 then s2 else "(" ^ s2 ^ ")" in
       Printf.sprintf "%s \\plus %s" s1_parenthesis s2_parenthesis, false
-  | Lollipop (e1, e2) -> formula_to_latex_atomic (Par (Orth e1, e2))
   | Ofcourse e ->
       let s, atomic = formula_to_latex_atomic e in
       let s_parenthesis = if atomic then s else "(" ^ s ^ ")" in
@@ -202,78 +167,5 @@ let rec formula_to_latex_atomic =
 let formula_to_latex formula =
   let s, _ = formula_to_latex_atomic formula in s
 
-let formula_list_to_latex formula_list =
-    String.concat ", " (List.map formula_to_latex formula_list);;
-
 let sequent_to_latex sequent =
-    formula_list_to_latex sequent.cons
-
-
-(* OPERATIONS *)
-
-let rec orthogonal =
-    function
-    | One -> Bottom
-    | Bottom -> One
-    | Top -> Zero
-    | Zero -> Top
-    | Litt x -> Orth (Litt x)
-    | Orth e -> e
-    | Tensor (e1, e2) -> Par (orthogonal e1, orthogonal e2)
-    | Par (e1, e2) -> Tensor (orthogonal e1, orthogonal e2)
-    | With (e1, e2) -> Plus (orthogonal e1, orthogonal e2)
-    | Plus (e1, e2) -> With (orthogonal e1, orthogonal e2)
-    | Lollipop (e1, e2) -> Tensor (e1, orthogonal e2)
-    | Ofcourse e -> Whynot (orthogonal e)
-    | Whynot e -> Ofcourse (orthogonal e);;
-
-let rec simplify =
-    function
-    | One -> One
-    | Bottom -> Bottom
-    | Top -> Top
-    | Zero -> Zero
-    | Litt x -> Litt x
-    | Orth e -> orthogonal (simplify e)
-    | Tensor (e1, e2) -> Tensor (simplify e1, simplify e2)
-    | Par (e1, e2) -> Par (simplify e1, simplify e2)
-    | With (e1, e2) -> With (simplify e1, simplify e2)
-    | Plus (e1, e2) -> Plus (simplify e1, simplify e2)
-    | Lollipop (e1, e2) -> Par (orthogonal (simplify e1), simplify e2)
-    | Ofcourse e -> Ofcourse (simplify e)
-    | Whynot e -> Whynot (simplify e);;
-
-let get_monolatery_sequent sequent =
-    {hyp=[]; cons=List.map simplify sequent.cons @ List.map orthogonal (List.map simplify sequent.hyp)};;
-
-exception Not_whynot;;
-
-let rec remove_whynot = function
-    | [] -> []
-    | Whynot e :: l -> e :: remove_whynot l
-    | _ -> raise Not_whynot;;
-
-let rec add_whynot = function
-    | [] -> []
-    | e :: l -> Whynot e :: add_whynot l;;
-
-let rec get_variable_names =
-    function
-    | One -> []
-    | Bottom -> []
-    | Top -> []
-    | Zero -> []
-    | Litt x -> [x]
-    | Orth e -> get_variable_names e
-    | Tensor (e1, e2) -> get_variable_names e1 @ get_variable_names e2
-    | Par (e1, e2) -> get_variable_names e1 @ get_variable_names e2
-    | With (e1, e2) -> get_variable_names e1 @ get_variable_names e2
-    | Plus (e1, e2) -> get_variable_names e1 @ get_variable_names e2
-    | Lollipop (e1, e2) -> get_variable_names e1 @ get_variable_names e2
-    | Ofcourse e -> get_variable_names e
-    | Whynot e -> get_variable_names e;;
-
-let get_unique_variable_names sequent =
-    let hyp_variables_with_duplicates = List.concat (List.map get_variable_names sequent.hyp) in
-    let cons_variables_with_duplicates = List.concat (List.map get_variable_names sequent.cons) in
-    List.sort_uniq String.compare (hyp_variables_with_duplicates @ cons_variables_with_duplicates)
+    String.concat ", " (List.map formula_to_latex sequent);;

--- a/sequent.ml
+++ b/sequent.ml
@@ -130,7 +130,7 @@ let rec formula_to_latex_atomic =
   | Top -> "\\top", true
   | Zero -> "\\zero", true
   | Litt x -> litteral_to_latex x, true
-  | Orth x -> Printf.sprintf "%s\\orth" x, true
+  | Orth x -> Printf.sprintf "{%s}\\orth" x, true
   | Tensor (e1, e2) ->
       let s1, atomic1 = formula_to_latex_atomic e1 in
       let s1_parenthesis = if atomic1 then s1 else "(" ^ s1 ^ ")" in


### PR DESCRIPTION
The idea:
- `raw_sequent` is an intermediate type between string/json and `sequent`.
- `raw_sequent` can be bilateral, can contain lollipop, and can have non-atomic dual, whereas `sequent` can not.
- `sequent` is an alias for `formula list`.
- No more `Axiom_left` or `Axiom_right` but only `Axiom_proof`