### PR TITLE
Non-provability checks

### DIFF
--- a/clauses.ml
+++ b/clauses.ml
@@ -1,0 +1,35 @@
+open Sequent
+
+(* Clauses : naive check of classical validity
+             could be replace by more efficient SAT checker *)
+
+let rec formula_to_clauses = function
+  | One -> []
+  | Bottom -> [[]]
+  | Top -> formula_to_clauses One
+  | Zero -> formula_to_clauses Bottom
+  | Litt x -> [[(x, true)]]
+  | Dual x -> [[(x, false)]]
+  | Tensor (f1, f2) ->
+     let c1 = formula_to_clauses f1 in
+     let c2 = formula_to_clauses f2 in
+     c1 @ c2
+  | Par (f1, f2) ->
+     let c1 = formula_to_clauses f1 in
+     let c2 = formula_to_clauses f2 in
+     List.concat_map (fun c -> List.map (List.append c) c2) c1
+  | With (f1, f2) -> formula_to_clauses (Tensor (f1, f2))
+  | Plus (f1, f2) -> formula_to_clauses (Par (f1, f2))
+  | Ofcourse f -> formula_to_clauses f
+  | Whynot f -> formula_to_clauses f
+
+let valid_clauses clauses =
+  let rec valid_clause = function
+    | [] -> false
+    | (x, b) :: tail ->
+       (List.exists (fun z -> z = (x, not b)) tail ||
+        valid_clause tail) 
+  in List.for_all valid_clause clauses
+
+let provable_sequent_as_classical sequent =
+  valid_clauses (formula_to_clauses (sequent_to_formula sequent))

--- a/phase.ml
+++ b/phase.ml
@@ -1,0 +1,80 @@
+open Sequent
+
+
+(* Phase models: give necessary (not sufficient) condition for provability *)
+
+type fact =
+  | Fbot
+  | Ftop
+  | Fint of int
+
+let rec fsum x y =
+match x, y with
+| Fint n, Fint m -> Fint (n + m)
+| Fbot, _ -> Fbot
+| _, Fbot -> Fbot
+| Ftop, _ -> Ftop
+| _, Ftop -> Ftop
+
+let rec fsup x y =
+match x, y with
+| Ftop, _ -> Ftop
+| _, Ftop -> Ftop
+| Fint n, Fint m -> if n = m then Fint n else Ftop
+| x, Fbot -> x
+| Fbot, x -> x
+
+let rec finf x y =
+match x, y with
+| Fbot, _ -> Fbot
+| _, Fbot -> Fbot
+| Fint n, Fint m -> if n = m then Fint n else Fbot
+| x, Ftop -> x
+| Ftop, x -> x
+
+let fone = Fint 0
+let fbot p = Fint p
+
+let fdual p = function
+  | Fbot -> Ftop
+  | Ftop -> Fbot
+  | Fint n -> Fint (p - n)
+
+let fpar p x y = fdual p (fsum (fdual p x) (fdual p y))
+
+let rec semantics p valuation = function
+  | One -> fone
+  | Bottom -> fbot p
+  | Top -> Ftop
+  | Zero -> Fbot
+  | Litt x -> Fint (valuation x)
+  | Dual x -> Fint (p - valuation x)
+  | Tensor (f1, f2) -> fsum (semantics p valuation f1) (semantics p valuation f2)
+  | Par (f1, f2) -> fpar p (semantics p valuation f1) (semantics p valuation f2)
+  | With (f1, f2) -> finf (semantics p valuation f1) (semantics p valuation f2)
+  | Plus (f1, f2) -> fsup (semantics p valuation f1) (semantics p valuation f2)
+  | Ofcourse f -> finf (semantics p valuation f) fone
+  | Whynot f -> fsup (semantics p valuation f) (fbot p)
+
+let valid_semantics p v f =
+  match semantics p v f with
+  | Ftop -> true
+  | Fint n -> n = 0
+  | Fbot -> false
+
+let delta_valuation reference atom =
+  if atom = reference then 1 else 0
+
+let zero_valuation atom = 0
+
+let rec sequent_to_formula = function
+  | [] -> Bottom
+  | [f] -> f
+  | f1 :: f2 :: context -> sequent_to_formula (Par (f1, f2) :: context)
+
+let valid_sequent sequent =
+  let variables = get_unique_variable_names sequent in
+  let formula = sequent_to_formula sequent in
+  valid_semantics 1 zero_valuation formula &&
+  List.for_all (fun x -> valid_semantics 0 (delta_valuation x) formula) variables
+

--- a/phase.ml
+++ b/phase.ml
@@ -1,6 +1,5 @@
 open Sequent
 
-
 (* Phase models: give necessary (not sufficient) condition for provability *)
 
 type fact =
@@ -67,14 +66,8 @@ let delta_valuation reference atom =
 
 let zero_valuation atom = 0
 
-let rec sequent_to_formula = function
-  | [] -> Bottom
-  | [f] -> f
-  | f1 :: f2 :: context -> sequent_to_formula (Par (f1, f2) :: context)
-
 let valid_sequent sequent =
   let variables = get_unique_variable_names sequent in
   let formula = sequent_to_formula sequent in
   valid_semantics 1 zero_valuation formula &&
   List.for_all (fun x -> valid_semantics 0 (delta_valuation x) formula) variables
-

--- a/sequent.ml
+++ b/sequent.ml
@@ -16,6 +16,11 @@ type formula =
 
 type sequent = formula list;;
 
+let rec sequent_to_formula = function
+  | [] -> Bottom
+  | [f] -> f
+  | f1 :: f2 :: context -> sequent_to_formula (Par (f1, f2) :: context)
+
 
 (* OPERATIONS *)
 


### PR DESCRIPTION
The following tests `sequent -> bool` must answer `true` if the sequent is provable:

- `valid_sequent` (testing some phase models in ℤ)
- `provable_sequent_as_classical` (the image in classical logic must be provable, naive test through clauses)

Turnstile symbol could be turned into red background if one of them fails.