### PR TITLE
[auto-reverse] remove dereliction on ??-formulas

### DIFF
--- a/proof.ml
+++ b/proof.ml
@@ -231,8 +231,6 @@ let apply_reversible_rule proof =
         with NotApplicable ->
     try try_rule_request sequent (Par (get_formula_position is_par sequent))
         with NotApplicable ->
-    try try_rule_request sequent (Dereliction (get_formula_position is_double_whynot sequent))
-        with NotApplicable ->
     try try_rule_request sequent (With (get_formula_position is_with sequent))
         with NotApplicable ->
     try try_rule_request sequent (Promotion (get_formula_position is_ofcourse sequent))

--- a/sequent.ml
+++ b/sequent.ml
@@ -74,7 +74,6 @@ let get_unique_variable_names sequent =
 let is_top = function | Top -> true | _ -> false;;
 let is_bottom = function | Bottom -> true | _ -> false;;
 let is_par = function | Par _ -> true | _ -> false;;
-let is_double_whynot = function | Whynot (Whynot _) -> true | _ -> false;;
 let is_with = function | With _ -> true | _ -> false;;
 let is_ofcourse = function | Ofcourse _ -> true | _ -> false;;
 

--- a/static/index.html
+++ b/static/index.html
@@ -163,7 +163,6 @@
             This includes not only the introduction rules for <span class="flip">&</span>, &, ⊥, ⊤, ! and 1, but also:</p>
             <ul>
                 <li>axiom rule for atomic formulas</li>
-                <li>dereliction rule on ?? formulas</li>
                 <li>⊗ rule with empty context</li>
             </ul>
         </div>


### PR DESCRIPTION
As a non-canonical operation, it should not be applied in auto-reverse.
Fixes #95.

- [ ] check tests