### PR TITLE
Implicit exchange

### DIFF
--- a/export_as_latex.ml
+++ b/export_as_latex.ml
@@ -2,7 +2,7 @@ open Proof
 
 exception Cannot_export_proof_as_latex_exception of string;;
 
-let proof_to_latex proof =
+let proof_to_latex implicit_exchange proof =
     let header = "% This LaTeX file has been generated using the Click&coLLect tool.\n"
         ^ "% https://click-and-collect.linear-logic.org/\n\n" in
     let packages = "\\documentclass{article}\n\n"
@@ -39,13 +39,13 @@ let proof_to_latex proof =
         ^ "  \\shipout\\box\\proof\n"
         ^ "}\n\n" in
     let start_proof = "\\begin{document}\n\n\\adaptpage{\n\\begin{prooftree}\n" in
-    let proof_lines = Proof.to_latex None proof in
+    let proof_lines = Proof.to_latex implicit_exchange None proof in
     let end_proof = "\\end{prooftree}\n}\n\n\\end{document}\n\n" in
     Printf.sprintf "%s%s%s%s%s%s" header packages macros start_proof proof_lines end_proof;;
 
-let export_as_latex_with_exceptions request_as_json =
+let export_as_latex_with_exceptions implicit_exchange request_as_json =
     let proof = Proof.from_json request_as_json in
-    proof_to_latex proof;;
+    proof_to_latex implicit_exchange proof;;
 
 let temp_directory = "local/var/temp";;
 
@@ -104,8 +104,8 @@ let get_png_file proof_as_latex =
     let png_file_name = Printf.sprintf "%s/%s-1.png" temp_directory file_prefix in
     read_and_remove_file png_file_name
 
-let export_as_latex request_as_json format =
-    try let proof_as_latex = export_as_latex_with_exceptions request_as_json in
+let export_as_latex implicit_exchange format request_as_json =
+    try let proof_as_latex = export_as_latex_with_exceptions implicit_exchange request_as_json in
         if format = "tex" then true, proof_as_latex, "text/plain"
         else if format = "pdf" then true, get_pdf_file proof_as_latex, "application/pdf"
         else if format = "png" then true, get_png_file proof_as_latex, "image/png"

--- a/export_as_latex.ml
+++ b/export_as_latex.ml
@@ -39,7 +39,7 @@ let proof_to_latex proof =
         ^ "  \\shipout\\box\\proof\n"
         ^ "}\n\n" in
     let start_proof = "\\begin{document}\n\n\\adaptpage{\n\\begin{prooftree}\n" in
-    let proof_lines = Proof.to_latex proof in
+    let proof_lines = Proof.to_latex None proof in
     let end_proof = "\\end{prooftree}\n}\n\n\\end{document}\n\n" in
     Printf.sprintf "%s%s%s%s%s%s" header packages macros start_proof proof_lines end_proof;;
 

--- a/focused_proof.ml
+++ b/focused_proof.ml
@@ -345,7 +345,7 @@ let permute_proof proof sequent_below =
     let sequent = get_conclusion proof in
     let indexed_sequent = index_list 0 sequent in
     let permutation = get_permutation indexed_sequent sequent_below in
-    Exchange_proof (sequent, permutation, proof)
+    Exchange_proof (sequent, permutation, permutation, proof)
 
 let rec weaken proof head tail = function
     | [] -> proof
@@ -362,7 +362,7 @@ let move_left left_offset right_offset proof =
         @ [n - right_offset - 1]
         @ List.init (n - right_offset - left_offset - 1) (fun k -> left_offset + k)
         @ List.init right_offset (fun k -> n - right_offset + k) in
-    Exchange_proof (sequent, permutation, proof)
+    Exchange_proof (sequent, permutation, permutation, proof)
 
 let move_right left_offset right_offset proof =
     let sequent = get_conclusion proof in
@@ -371,7 +371,7 @@ let move_right left_offset right_offset proof =
         @ List.init (n - right_offset - left_offset - 1) (fun k -> left_offset + 1 + k)
         @ [left_offset]
         @ List.init right_offset (fun k -> n - right_offset + k) in
-    Exchange_proof (sequent, permutation, proof)
+    Exchange_proof (sequent, permutation, permutation, proof)
 
 let rec unfocus_proof = function
     | Null -> raise (Failure "Focused proof is null")

--- a/proof.ml
+++ b/proof.ml
@@ -414,10 +414,15 @@ let to_coq_with_hyps = to_coq_with_hyps_increment 0
 let latex_apply latex_rule conclusion =
     Printf.sprintf "  \\%s{%s}\n" latex_rule conclusion
 
+let nonify = function
+  | None -> None
+  | Some _ -> Some None
+
 let rec to_latex exchange proof =
 (* exchange is [None] for explicit exchange,
                [Some None] for implicit exchange with no permutation to apply to conclusion,
                [Some (Some permutation)] for implicit exchange with [permutation] to be applied to conclusion *)
+    let to_latex_clear_exchange = to_latex (nonify exchange) in
     let conclusion =
       let preconclusion = get_conclusion proof in
       match exchange with
@@ -427,16 +432,16 @@ let rec to_latex exchange proof =
     | Axiom_proof _ -> latex_apply "axv" conclusion
     | One_proof -> latex_apply "onev" conclusion
     | Top_proof _ -> latex_apply "topv" conclusion
-    | Bottom_proof (_, _, p) -> to_latex (Some None) p ^ (latex_apply "botv" conclusion)
-    | Tensor_proof (_, _, _, _, p1, p2) -> to_latex (Some None) p1 ^ (to_latex (Some None) p2) ^ (latex_apply "tensorv" conclusion)
-    | Par_proof (_, _, _, _, p) -> to_latex (Some None) p ^ (latex_apply "parrv" conclusion)
-    | With_proof (_, _, _, _, p1, p2) -> to_latex (Some None) p1 ^ (to_latex (Some None) p2) ^ (latex_apply "withv" conclusion)
-    | Plus_left_proof (_, _, _, _, p) -> to_latex (Some None) p ^ (latex_apply "pluslv" conclusion)
-    | Plus_right_proof (_, _, _, _, p) -> to_latex (Some None) p ^ (latex_apply "plusrv" conclusion)
-    | Promotion_proof (_, _, _, p) -> to_latex (Some None) p ^ (latex_apply "ocv" conclusion)
-    | Dereliction_proof (_, _, _, p) -> to_latex (Some None) p ^ (latex_apply "dev" conclusion)
-    | Weakening_proof (_, _, _, p) -> to_latex (Some None) p ^ (latex_apply "wkv" conclusion)
-    | Contraction_proof (_, _, _, p) -> to_latex (Some None) p ^ (latex_apply "cov" conclusion)
+    | Bottom_proof (_, _, p) -> to_latex_clear_exchange p ^ (latex_apply "botv" conclusion)
+    | Tensor_proof (_, _, _, _, p1, p2) -> to_latex_clear_exchange p1 ^ (to_latex_clear_exchange p2) ^ (latex_apply "tensorv" conclusion)
+    | Par_proof (_, _, _, _, p) -> to_latex_clear_exchange p ^ (latex_apply "parrv" conclusion)
+    | With_proof (_, _, _, _, p1, p2) -> to_latex_clear_exchange p1 ^ (to_latex_clear_exchange p2) ^ (latex_apply "withv" conclusion)
+    | Plus_left_proof (_, _, _, _, p) -> to_latex_clear_exchange p ^ (latex_apply "pluslv" conclusion)
+    | Plus_right_proof (_, _, _, _, p) -> to_latex_clear_exchange p ^ (latex_apply "plusrv" conclusion)
+    | Promotion_proof (_, _, _, p) -> to_latex_clear_exchange p ^ (latex_apply "ocv" conclusion)
+    | Dereliction_proof (_, _, _, p) -> to_latex_clear_exchange p ^ (latex_apply "dev" conclusion)
+    | Weakening_proof (_, _, _, p) -> to_latex_clear_exchange p ^ (latex_apply "wkv" conclusion)
+    | Contraction_proof (_, _, _, p) -> to_latex_clear_exchange p ^ (latex_apply "cov" conclusion)
     | Exchange_proof (_, display_permutation, permutation, p) ->
        (match exchange with
         | None -> to_latex None p ^ (latex_apply "exv" conclusion)

--- a/proof.ml
+++ b/proof.ml
@@ -17,7 +17,7 @@ type proof =
     | Dereliction_proof of formula list * formula * formula list * proof
     | Weakening_proof of formula list * formula * formula list * proof
     | Contraction_proof of formula list * formula * formula list * proof
-    | Exchange_proof of sequent * int list * proof
+    | Exchange_proof of sequent * int list * int list * proof
     | Hypothesis_proof of sequent;;
 
 
@@ -56,7 +56,7 @@ let get_premises = function
     | Dereliction_proof (_, _, _, p) -> [p]
     | Weakening_proof (_, _, _, p) -> [p]
     | Contraction_proof (_, _, _, p) -> [p]
-    | Exchange_proof (_, _, p) -> [p]
+    | Exchange_proof (_, _, _, p) -> [p]
     | Hypothesis_proof s -> raise (Failure "Can not get premises of hypothesis");;
 
 let set_premises proof premises = match proof, premises with
@@ -74,7 +74,7 @@ let set_premises proof premises = match proof, premises with
     | Dereliction_proof (head, e, tail, _), [p] -> Dereliction_proof (head, e, tail, p)
     | Weakening_proof (head, e, tail, _), [p] -> Weakening_proof (head, e, tail, p)
     | Contraction_proof (head, e, tail, _), [p] -> Contraction_proof (head, e, tail, p)
-    | Exchange_proof (sequent, permutation, _), [p] -> Exchange_proof (sequent, permutation, p)
+    | Exchange_proof (sequent, permutation1, permutation2, _), [p] -> Exchange_proof (sequent, permutation1, permutation2, p)
     | Hypothesis_proof sequent, _ -> raise (Failure "Can not set premises of hypothesis")
     | _ -> raise (Failure "Number of premises mismatch with given proof");;
 
@@ -95,7 +95,7 @@ let get_conclusion = function
     | Dereliction_proof (head, e, tail, _) -> head @ [Whynot e] @ tail
     | Weakening_proof (head, e, tail, _) -> head @ [Whynot e] @ tail
     | Contraction_proof (head, e, tail, _) -> head @ [Whynot e] @ tail
-    | Exchange_proof (sequent, permutation, _) -> permute sequent permutation
+    | Exchange_proof (sequent, _, permutation, _) -> permute sequent permutation
     | Hypothesis_proof sequent -> sequent;;
 
 
@@ -200,7 +200,8 @@ let rec from_sequent_and_rule_request sequent rule_request =
             else if not (is_valid_permutation permutation)
             then raise (Rule_exception (false, "When applying exchange rule, formula_positions should be a permutation of the size of sequent formula list"))
             else let permuted_sequent = permute sequent permutation in
-            Exchange_proof (permuted_sequent, permutation_inverse permutation, (Hypothesis_proof permuted_sequent))
+                 let permutation_inv = permutation_inverse permutation in
+                 Exchange_proof (permuted_sequent, permutation_inv, permutation_inv, Hypothesis_proof permuted_sequent)
         );;
 
 let from_sequent_and_rule_request_and_premises sequent rule_request premises =
@@ -286,7 +287,7 @@ let get_rule_request = function
     | Dereliction_proof (head, _, _, _) -> Dereliction (List.length head)
     | Weakening_proof (head, _, _, _) -> Weakening (List.length head)
     | Contraction_proof (head, _, _, _) -> Contraction (List.length head)
-    | Exchange_proof (_, permutation, _) -> Exchange (permutation_inverse permutation)
+    | Exchange_proof (_, _, permutation, _) -> Exchange (permutation_inverse permutation)
     | Hypothesis_proof _ -> raise (Failure "Can not get rule request of hypothesis");;
 
 
@@ -401,7 +402,7 @@ let rec to_coq_with_hyps_increment i = function
     | Contraction_proof (head, _, _, p) ->
         let s, n, hyps = to_coq_with_hyps_increment i p in
         coq_apply_with_args "co_r_ext" [formula_list_to_coq head] ^ s, n, hyps
-    | Exchange_proof (sequent, permutation, p) ->
+    | Exchange_proof (sequent, _, permutation, p) ->
         let s, n, hyps = to_coq_with_hyps_increment i p in
         coq_apply_with_args "ex_perm_r" [permutation_to_coq permutation; formula_list_to_coq sequent] ^ s, n, hyps
     | Hypothesis_proof sequent -> coq_apply ("Hyp" ^ string_of_int i), i + 1, [Sequent.sequent_to_coq sequent];;
@@ -414,23 +415,33 @@ let to_coq_with_hyps = to_coq_with_hyps_increment 0
 let latex_apply latex_rule conclusion =
     Printf.sprintf "  \\%s{%s}\n" latex_rule conclusion
 
-let rec to_latex proof =
-    let conclusion = sequent_to_latex (get_conclusion proof) in
+let rec to_latex exchange proof =
+(* exchange is [None] for explicit exchange,
+               [Some None] for implicit exchange with no permutation to apply to conclusion,
+               [Some (Some permutation)] for implicit exchange with [permutation] to be applied to conclusion *)
+    let conclusion =
+      let preconclusion = get_conclusion proof in
+      match exchange with
+      | None | Some None -> sequent_to_latex preconclusion
+      | Some (Some permutation) -> sequent_to_latex (permute preconclusion permutation) in
     match proof with
     | Axiom_proof _ -> latex_apply "axv" conclusion
     | One_proof -> latex_apply "onev" conclusion
     | Top_proof _ -> latex_apply "topv" conclusion
-    | Bottom_proof (_, _, p) -> to_latex p ^ (latex_apply "botv" conclusion)
-    | Tensor_proof (_, _, _, _, p1, p2) -> to_latex p1 ^ (to_latex p2) ^ (latex_apply "tensorv" conclusion)
-    | Par_proof (_, _, _, _, p) -> to_latex p ^ (latex_apply "parrv" conclusion)
-    | With_proof (_, _, _, _, p1, p2) -> to_latex p1 ^ (to_latex p2) ^ (latex_apply "withv" conclusion)
-    | Plus_left_proof (_, _, _, _, p) -> to_latex p ^ (latex_apply "pluslv" conclusion)
-    | Plus_right_proof (_, _, _, _, p) -> to_latex p ^ (latex_apply "plusrv" conclusion)
-    | Promotion_proof (_, _, _, p) -> to_latex p ^ (latex_apply "ocv" conclusion)
-    | Dereliction_proof (_, _, _, p) -> to_latex p ^ (latex_apply "dev" conclusion)
-    | Weakening_proof (_, _, _, p) -> to_latex p ^ (latex_apply "wkv" conclusion)
-    | Contraction_proof (_, _, _, p) -> to_latex p ^ (latex_apply "cov" conclusion)
-    | Exchange_proof (_, _, p) -> to_latex p ^ (latex_apply "exv" conclusion)
+    | Bottom_proof (_, _, p) -> to_latex (Some None) p ^ (latex_apply "botv" conclusion)
+    | Tensor_proof (_, _, _, _, p1, p2) -> to_latex (Some None) p1 ^ (to_latex (Some None) p2) ^ (latex_apply "tensorv" conclusion)
+    | Par_proof (_, _, _, _, p) -> to_latex (Some None) p ^ (latex_apply "parrv" conclusion)
+    | With_proof (_, _, _, _, p1, p2) -> to_latex (Some None) p1 ^ (to_latex (Some None) p2) ^ (latex_apply "withv" conclusion)
+    | Plus_left_proof (_, _, _, _, p) -> to_latex (Some None) p ^ (latex_apply "pluslv" conclusion)
+    | Plus_right_proof (_, _, _, _, p) -> to_latex (Some None) p ^ (latex_apply "plusrv" conclusion)
+    | Promotion_proof (_, _, _, p) -> to_latex (Some None) p ^ (latex_apply "ocv" conclusion)
+    | Dereliction_proof (_, _, _, p) -> to_latex (Some None) p ^ (latex_apply "dev" conclusion)
+    | Weakening_proof (_, _, _, p) -> to_latex (Some None) p ^ (latex_apply "wkv" conclusion)
+    | Contraction_proof (_, _, _, p) -> to_latex (Some None) p ^ (latex_apply "cov" conclusion)
+    | Exchange_proof (_, permutation, _, p) -> 
+       (match exchange with
+        | None -> to_latex None p ^ (latex_apply "exv" conclusion)
+        | Some _ -> to_latex (Some (Some permutation)) p)
     | Hypothesis_proof _ -> latex_apply "hypv" conclusion;;
 
 
@@ -464,7 +475,7 @@ let rec commute_permutations proof perm =
         Bottom_proof (permute conclusion head_perm, permute conclusion tail_perm, commute_permutations p new_perm)
     | Tensor_proof (head, _, _, tail, p1, p2) ->
         let new_proof = set_premises proof [commute_permutations p1 (identity (List.length head + 1)); commute_permutations p2 (identity (1 + List.length tail))] in
-        if perm = identity (List.length conclusion) then new_proof else Exchange_proof (conclusion, perm, new_proof)
+        if perm = identity (List.length conclusion) then new_proof else Exchange_proof (conclusion, perm, perm, new_proof)
     | Par_proof (head, e1, e2, tail, p) ->
         let head_perm, tail_perm = head_tail_perm head perm in
         let new_perm = perm_plus_element (List.length head) perm in
@@ -493,7 +504,7 @@ let rec commute_permutations proof perm =
         let head_perm, tail_perm = head_tail_perm head perm in
         let new_perm = perm_plus_element (List.length head) perm in
         Contraction_proof (permute conclusion head_perm, formula, permute conclusion tail_perm, commute_permutations p new_perm)
-    | Exchange_proof (_, permutation, p) -> commute_permutations p (permute permutation perm)
+    | Exchange_proof (_, _, permutation, p) -> commute_permutations p (permute permutation perm)
     | Hypothesis_proof s -> Hypothesis_proof (permute s perm);;
 
 
@@ -709,14 +720,15 @@ let rec rec_commute_down_weakenings proof =
                 new_head_wk_tail_wk_head_tail head tail head_wk tail_wk (Whynot e) 2 in
             let new_proof = get_commuted_proof (rec_commute_down_weakenings (Contraction_proof (new_head, e, new_tail, p))) in
             true, Weakening_proof (new_head_wk, formula, new_tail_wk, new_proof)
-    | Exchange_proof (s, permutation, Weakening_proof (head_wk, formula, tail_wk, p)) ->
+    | Exchange_proof (s, permutation1, permutation2, Weakening_proof (head_wk, formula, tail_wk, p)) ->
         let n_head_wk = List.length head_wk in
         let n_tail_wk = List.length tail_wk in
-        let new_permutation = perm_minus_element n_head_wk permutation in
-        let exchange_proof = if new_permutation = identity (n_head_wk + n_tail_wk) then p else Exchange_proof (head_wk @ tail_wk, new_permutation, p) in
+        let new_permutation1 = perm_minus_element n_head_wk permutation1 in
+        let new_permutation2 = perm_minus_element n_head_wk permutation2 in
+        let exchange_proof = if new_permutation2 = identity (n_head_wk + n_tail_wk) then p else Exchange_proof (head_wk @ tail_wk, new_permutation1, new_permutation2, p) in
         let new_proof = get_commuted_proof (rec_commute_down_weakenings exchange_proof) in
         let conclusion = get_conclusion proof in
-        let new_head_wk, _, new_tail_wk = head_formula_tail (position_in_list (List.length head_wk) permutation) conclusion in
+        let new_head_wk, _, new_tail_wk = head_formula_tail (position_in_list (List.length head_wk) permutation2) conclusion in
         true, Weakening_proof (new_head_wk, formula, new_tail_wk, new_proof)
     | _ -> let commuted_premises = List.map rec_commute_down_weakenings (get_premises proof) in
         let new_proof = set_premises proof (List.map get_commuted_proof commuted_premises) in

--- a/proof.ml
+++ b/proof.ml
@@ -441,7 +441,9 @@ let rec to_latex implicit_exchange permutation_opt proof =
     | Exchange_proof (_, display_permutation, permutation, p) ->
         if implicit_exchange
             then to_latex implicit_exchange (Some display_permutation) p
-            else to_latex implicit_exchange None p ^ (latex_apply "exv" conclusion)
+            else to_latex implicit_exchange None p ^
+                if permutation = identity (List.length permutation) then ""
+                else (latex_apply "exv" conclusion)
     | Hypothesis_proof _ -> latex_apply "hypv" conclusion;;
 
 

--- a/proof.ml
+++ b/proof.ml
@@ -417,7 +417,7 @@ let latex_apply latex_rule conclusion =
 let rec to_latex implicit_exchange permutation_opt proof =
     (* implicit_exchange is true when we don't display exchange rule.
        permutation_opt is [None] when conclusion is to display as is,
-       [Some permutation] if we need to permute it bofore *)
+       [Some permutation] if we need to permute it before *)
     let to_latex_clear_exchange = to_latex implicit_exchange None in
     let conclusion =
       let preconclusion = get_conclusion proof in

--- a/rule_request.ml
+++ b/rule_request.ml
@@ -15,7 +15,7 @@ type rule_request =
     | Dereliction of int
     | Weakening of int
     | Contraction of int
-    | Exchange of int list;;
+    | Exchange of int list * int list;;
 
 
 (* JSON -> RULE *)
@@ -63,7 +63,7 @@ let from_json rule_request_as_json =
         | "dereliction" -> Dereliction (get_int rule_request_as_json "formulaPosition")
         | "weakening" -> Weakening (get_int rule_request_as_json "formulaPosition")
         | "contraction" -> Contraction (get_int rule_request_as_json "formulaPosition")
-        | "exchange" -> Exchange (get_int_list rule_request_as_json "permutation")
+        | "exchange" -> Exchange (get_int_list rule_request_as_json "displayPermutation", get_int_list rule_request_as_json "permutation")
         | _ -> raise (Json_exception ("unknown rule '" ^ rule ^ "'"));;
 
 (* RULE -> JSON *)
@@ -105,6 +105,7 @@ let to_json = function
     | Contraction formula_position -> `Assoc [
         ("rule", `String "contraction");
         ("formulaPosition", `Int formula_position)]
-    | Exchange permutation -> `Assoc [
+    | Exchange (display_permutation, permutation) -> `Assoc [
         ("rule", `String "exchange");
+        ("displayPermutation", `List (List.map (fun n -> `Int n) display_permutation));
         ("permutation", `List (List.map (fun n -> `Int n) permutation))];;

--- a/static/js/proof.js
+++ b/static/js/proof.js
@@ -65,11 +65,12 @@ function initProof(proofAsJson, $container, options = {}) {
 function createSubProof(proofAsJson, $subProofDivContainer, options) {
     let $sequentTable = createSequentTable(proofAsJson.sequent, options);
     $subProofDivContainer.prepend($sequentTable);
+
     if (proofAsJson.appliedRule) {
-        let permutationBeforeRule = null;
+        let permutationBeforeRule = getSequentIdentityPermutation(proofAsJson.sequent);
 
         if (proofAsJson.appliedRule.ruleRequest.rule === 'exchange') {
-            permutationBeforeRule = {'hyp': [], 'cons': proofAsJson.appliedRule.ruleRequest.permutation};
+            permutationBeforeRule = {'hyp': [], 'cons': invertPermutation(proofAsJson.appliedRule.ruleRequest.permutation)};
             proofAsJson = proofAsJson.appliedRule.premises[0];
         }
 
@@ -269,12 +270,23 @@ function recGetProofAsJson($sequentTable) {
         appliedRule = { ruleRequest, premises };
 
         let permutationBeforeRule = $sequentTable.data('permutationBeforeRule');
-        if (!isIdentitySequentPermutation(permutationBeforeRule)) {
+        let displayPermutation = getSequentPermutation($sequentTable);
+        if (!isIdentitySequentPermutation(permutationBeforeRule)
+            || !isIdentitySequentPermutation(displayPermutation)) {
             let sequentWithPermutation = permuteSequent(sequentWithoutPermutation, permutationBeforeRule);
+
+            // Permutation asked by API is from premise to conclusion, and we have the other way
+            // We need to invert permutation
+            let invertedPermutation = invertPermutation(permutationBeforeRule['cons']);
+
+            // Display permutation asked by API is from premise to displayed conclusion
+            let permutedDisplayPermutation = permute(invertedPermutation, displayPermutation['cons']);
+
             appliedRule = {
                 ruleRequest: {
                     rule: 'exchange',
-                    permutation: permutationBeforeRule['cons']
+                    permutation: invertedPermutation,
+                    displayPermutation: permutedDisplayPermutation
                 },
                 premises: [{sequent: sequentWithPermutation, appliedRule}]
             }
@@ -285,10 +297,6 @@ function recGetProofAsJson($sequentTable) {
 }
 
 function isIdentitySequentPermutation(sequentPermutation) {
-    if (sequentPermutation === null) {
-        return true;
-    }
-
     return isIdentity(sequentPermutation['hyp']) && isIdentity(sequentPermutation['cons']);
 }
 
@@ -300,6 +308,14 @@ function isIdentity(permutation) {
     }
 
     return true;
+}
+
+function invertPermutation(permutation) {
+    let invertedPerm = [];
+    for (let i of identity(permutation.length)) {
+        invertedPerm.push(permutation.indexOf(i));
+    }
+    return invertedPerm;
 }
 
 // **********************

--- a/static/js/proof.js
+++ b/static/js/proof.js
@@ -413,21 +413,21 @@ function createExportBar($container) {
         'images/LaTeX_logo.png',
         'Export as LaTeX',
         'latex',
-        function () { exportAsLatex($container, 'tex'); });
+        function () { exportAsLatex($container, 'tex', false); });
     $exportBar.append(latexButton);
 
     let pdfButton = createExportButton(
         'images/pdf-icon.png',
         'Export as PDF',
         'pdf',
-        function () { exportAsLatex($container, 'pdf'); });
+        function () { exportAsLatex($container, 'pdf', false); });
     $exportBar.append(pdfButton);
 
     let pngButton = createExportButton(
         'images/camera.png',
         'Export as PNG',
         'png',
-        function () { exportAsLatex($container, 'png'); });
+        function () { exportAsLatex($container, 'png', true); });
     $exportBar.append(pngButton);
 
     $container.append($exportBar);
@@ -471,12 +471,12 @@ function exportAsCoq($container) {
 // EXPORT AS LATEX
 // ***************
 
-function exportAsLatex($container, format) {
+function exportAsLatex($container, format, implicitExchange) {
     // We get proof stored in HTML
     let proofAsJson = getProofAsJson($container);
 
     let httpRequest = new XMLHttpRequest();
-    httpRequest.open('POST', `/export_as_latex?format=${format}`, true);
+    httpRequest.open('POST', `/export_as_latex?format=${format}&implicitExchange=${implicitExchange}`, true);
     httpRequest.responseType = 'blob';
     httpRequest.setRequestHeader('Content-Type', "application/json; charset=UTF-8");
 

--- a/static/js/proof.js
+++ b/static/js/proof.js
@@ -427,7 +427,7 @@ function createExportBar($container) {
         'images/camera.png',
         'Export as PNG',
         'png',
-        function () { exportAsLatex($container, 'png', true); });
+        function () { exportAsLatex($container, 'png', false); });
     $exportBar.append(pngButton);
 
     $container.append($exportBar);

--- a/static/js/sequent.js
+++ b/static/js/sequent.js
@@ -298,14 +298,29 @@ function getFormulasPermutation($ul) {
     return permutation;
 }
 
-function permuteSequent(sequentWithoutPermutation, sequentPermutation) {
+function getSequentIdentityPermutation(sequent) {
     return {
-        'hyp': permuteFormulas(sequentWithoutPermutation['hyp'], sequentPermutation['hyp']),
-        'cons': permuteFormulas(sequentWithoutPermutation['cons'], sequentPermutation['cons'])
+        'hyp': getFormulaListIdentityPermutation(sequent['hyp'] || []),
+        'cons': getFormulaListIdentityPermutation(sequent['cons'] || [])
     };
 }
 
-function permuteFormulas(formulasWithoutPermutation, formulasPermutation) {
+function getFormulaListIdentityPermutation(formulaList) {
+    return identity(formulaList.length);
+}
+
+function identity(n) {
+    return [...Array(n).keys()];
+}
+
+function permuteSequent(sequentWithoutPermutation, sequentPermutation) {
+    return {
+        'hyp': permute(sequentWithoutPermutation['hyp'], sequentPermutation['hyp']),
+        'cons': permute(sequentWithoutPermutation['cons'], sequentPermutation['cons'])
+    };
+}
+
+function permute(formulasWithoutPermutation, formulasPermutation) {
     let newFormulas = [];
 
     for (let initialPosition of formulasPermutation) {


### PR DESCRIPTION
Extend the exchange rule with an additional permutation which can be used to encode the current state on screen and relied on for export with an [implicit exchange rule](https://github.com/etiennecallies/click-and-collect/wiki/Enhancement-Proposals#implicit-exchange).
LaTeX export is extended with an implicit exchange version.