### PR TITLE
Update implicit/explicit export comments

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -168,8 +168,8 @@
         </div>
 
         <div id="export-dialog" title="Select export option" class="dialog">
-            <p class="implicit"><span class="bold">Implicit exchanges:</span> no exchange will appear in the export. The output will look like what is displayed in the interface.</p>
-            <p class="explicit"><span class="bold">Explicit exchanges:</span> some exchanges will appear in the export only when needed (just below tensor rules). Derivation rules strictly apply through the proof.</p>
+            <p class="implicit"><span class="bold">Implicit exchanges:</span> no exchange rule will appear in the export. The output will look like what is displayed in the interface (snapshot).</p>
+            <p class="explicit"><span class="bold">Explicit exchanges:</span> some exchanges will appear in the export. Derivation rules strictly apply through the proof.</p>
         </div>
 
         <div class="section-wrapper">


### PR DESCRIPTION
The current behavior is good, but comments in the export window were misleading: explicit export may contain exchanges without tensor rules:
![ie](https://user-images.githubusercontent.com/30601497/117815190-8358ad80-b265-11eb-9a86-05215a9338d8.png)
