### PR TITLE
UTF-8 headers

### DIFF
--- a/main.ml
+++ b/main.ml
@@ -48,7 +48,7 @@ let plain_text_handler plain_text_function req =
 let static_handler = Middleware.static_unix ~local_path:"./static" ~uri_prefix:"/static" ();;
 
 let index_handler _request =
-    Response.of_file "./index.html";;
+    Response.of_file "./index.html" ~mime:"text/html; charset=utf-8";;
 
 let parse_sequent_handler req =
     common_get_handler safe_parse "sequent_as_string" req ;;


### PR DESCRIPTION
### legacy PREPROD
https://linearon.modusponens.dev/
should work (version deployed before switch to opium)
```
Content-Encoding: gzip
Content-Type: text/html; charset=utf-8
Transfer-Encoding: chunked
```

### PREPROD
https://ccll.linear-logic.org/ currently deployed with this branch
may work if this PR fixes the issue. @lionelvaux do you confirm?
```
Content-Encoding: gzip
Content-Length: 4795
Content-Type: text/html; charset=utf-8
Vary: Accept-Encoding
```

### PROD
https://click-and-collect.linear-logic.org/
should not work
```
Content-Encoding: gzip
Content-Length: 4795
Content-Type: text/html
Vary: Accept-Encoding
```