### PR TITLE
Axiom expansion

### DIFF
--- a/apply_rule.ml
+++ b/apply_rule.ml
@@ -1,22 +1,8 @@
-exception Bad_request_exception of string
-
-let get_key d k =
-    let value =
-        try Yojson.Basic.Util.member k d
-        with Yojson.Basic.Util.Type_error (_, _) -> raise (Bad_request_exception ("request body must be a json object"))
-    in
-    if value = `Null
-    then raise (Bad_request_exception ("required argument '" ^ k ^ "' is missing"))
-    else value
-
 let apply_rule_with_exceptions request_as_json =
-    let rule_request_as_json = get_key request_as_json "ruleRequest" in
+    let rule_request_as_json = Request_utils.get_key request_as_json "ruleRequest" in
     let rule_request = Rule_request.from_json rule_request_as_json in
-    let sequent_as_json = get_key request_as_json "sequent" in
-    let sequent = Raw_sequent.sequent_from_json sequent_as_json in
-    let notations_as_json = get_key request_as_json "notations" in
-    let notations = Notations.from_json notations_as_json in
-    Proof.from_sequent_and_rule_request sequent notations rule_request
+    let sequent_with_notations = Sequent_with_notations.from_json request_as_json in
+    Proof.from_sequent_and_rule_request sequent_with_notations.sequent sequent_with_notations.notations rule_request
 
 let apply_rule request_as_json =
     try let proof = apply_rule_with_exceptions request_as_json in
@@ -26,10 +12,9 @@ let apply_rule request_as_json =
             ("proof", proof_as_json)
         ]
     with
-        | Bad_request_exception m -> false, `String ("Bad request: " ^ m)
+        | Request_utils.Bad_request_exception m -> false, `String ("Bad request: " ^ m)
         | Rule_request.Json_exception m -> false, `String ("Bad rule json: " ^ m)
-        | Raw_sequent.Json_exception m -> false, `String ("Bad sequent json: " ^ m)
-        | Notations.Json_exception m -> false, `String ("Bad notations json: " ^ m)
+        | Sequent_with_notations.Json_exception m -> false, `String ("Bad sequent with notations: " ^ m)
         | Proof.Rule_exception (is_pedagogic, m) -> if is_pedagogic
             then true, `Assoc [("success", `Bool false); ("errorMessage", `String m)]
             else false, `String m

--- a/index.html
+++ b/index.html
@@ -184,7 +184,7 @@
         <div id="proof-transformation-dialog" title="Proof transformation mode" class="dialog">
             <p>When switched-on this option allows you to work on a proof.</p>
             <ul>
-                <li>You can click on ⇯ button to expand one axiom rule.</li>
+                <li>You can click on ⇯ button to expand an axiom rule (applies reversible rules first). Double-click to fully expand an axiom.</li>
             </ul>
         </div>
 

--- a/index.html
+++ b/index.html
@@ -181,6 +181,13 @@
                 Click on the position you would like to cut (a comma <span class="code">,</span> between two formulas or a point <span class="code">.</span> at the beginning or end of a sequent), and type your formula in the popup.</p>
         </div>
 
+        <div id="proof-transformation-dialog" title="Proof transformation mode" class="dialog">
+            <p>When switched-on this option allows you to work on a proof.</p>
+            <ul>
+                <li>You can click on ⇯ button to expand one axiom rule.</li>
+            </ul>
+        </div>
+
         <div id="cut-formula-dialog" title="Enter cut formula" class="dialog">
             <form action="#">
                 <label>

--- a/main.ml
+++ b/main.ml
@@ -84,6 +84,9 @@ let export_as_latex_handler req =
 let get_proof_transformation_options_handler req =
     json_handler Proof_transformation.get_proof_transformation_options req
 
+let apply_transformation_handler req =
+    json_handler Proof_transformation.apply_transformation req
+
 (** Configure the logger *)
 let set_logger () =
   Logs.set_reporter (Logs_fmt.reporter ());
@@ -107,5 +110,6 @@ let _ =
   |> App.post "/export_as_coq" export_as_coq_handler
   |> App.post "/export_as_latex/:format/:implicit_exchange" export_as_latex_handler
   |> App.post "/get_proof_transformation_options" get_proof_transformation_options_handler
+  |> App.post "/apply_transformation" apply_transformation_handler
   |> App.run_command
 ;;

--- a/proof.ml
+++ b/proof.ml
@@ -352,14 +352,18 @@ let get_rule_request = function
 (* PROOF -> TRANSFORM OPTION *)
 
 let get_transform_options notations = function
-    | Axiom_proof f -> begin match f with
-        | Litt s | Dual s -> if List.mem_assoc s notations then [Expand_axiom] else []
-        | _ -> [Expand_axiom] end
+    | Axiom_proof f -> let expand_axiom_enabled = match f with
+        | Litt s | Dual s -> List.mem_assoc s notations
+        | _ -> true in
+        [Expand_axiom, expand_axiom_enabled]
     | _ -> [];;
 
 let get_transform_options_as_json notations proof =
     let transform_options = get_transform_options notations proof in
-    `List (List.map (fun transform_option -> `String (Transform_request.to_string transform_option)) transform_options)
+    `List (List.map (fun (transform_option, enabled) -> `Assoc [
+        ("transformation", `String (Transform_request.to_string transform_option));
+        ("enabled", `Bool enabled)
+        ]) transform_options)
 
 
 (* JSON -> PROOF *)

--- a/proof_transformation.ml
+++ b/proof_transformation.ml
@@ -1,6 +1,67 @@
+open Sequent
+open Proof
+open Proof_with_notations
+open Transform_request
+
+exception Transform_exception of string;;
+
+let expand_axiom formula =
+    match formula with
+    | One -> Axiom_proof formula (* TODO apply Bottom then One ? *)
+    | Bottom -> Axiom_proof formula (* TODO apply Bottom then One ? *)
+    | Top -> Axiom_proof formula (* TODO apply Top ? *)
+    | Zero -> Axiom_proof formula (* TODO apply Top ? *)
+    | Litt _s -> Axiom_proof formula (* TODO notations *)
+    | Dual _s -> Axiom_proof formula (* TODO notations *)
+    | Tensor (e1, e2) -> begin
+         let e1' = dual e1 in
+         let e2' = dual e2 in
+         let tensor_proof = Tensor_proof ([e1'], e1, e2, [e2'], Axiom_proof e1', Axiom_proof e2) in
+         let permutation = [1; 0; 2] in
+         let exchange_proof = Exchange_proof ([e1'; Tensor (e1, e2); e2'], permutation, permutation, tensor_proof) in
+         Par_proof ([Tensor (e1, e2)], e1', e2', [], exchange_proof)
+     end
+    | Par (e1, e2) -> begin
+        let e1' = dual e1 in
+        let e2' = dual e2 in
+        let tensor_proof = Tensor_proof ([e1], e1', e2', [e2], Axiom_proof e1, Axiom_proof e2') in
+        let permutation = [0; 2; 1] in
+        let exchange_proof = Exchange_proof ([e1; Tensor (e1', e2'); e2], permutation, permutation, tensor_proof) in
+        Par_proof ([], e1, e2, [Tensor (e1', e2')], exchange_proof)
+    end
+    | With (e1, e2) -> begin
+        let e1' = dual e1 in
+        let e2' = dual e2 in
+        let plus_left_proof = Plus_left_proof ([e1], e1', e2', [], Axiom_proof e1) in
+        let plus_right_proof = Plus_right_proof ([e2], e1', e2', [], Axiom_proof e2) in
+        With_proof ([], e1, e2, [Plus (e1', e2')], plus_left_proof, plus_right_proof)
+    end
+    | Plus (e1, e2) -> begin
+       let e1' = dual e1 in
+       let e2' = dual e2 in
+       let plus_left_proof = Plus_left_proof ([], e1, e2, [e1'], Axiom_proof e1) in
+       let plus_right_proof = Plus_right_proof ([], e1, e2, [e2'], Axiom_proof e2) in
+       With_proof ([Plus (e1, e2)], e1', e2', [], plus_left_proof, plus_right_proof)
+    end
+    | Ofcourse e -> begin
+       let e' = dual e in
+       Promotion_proof ([], e, [e'], Dereliction_proof ([e], e', [], Axiom_proof e))
+    end
+    | Whynot e -> begin
+        let e' = dual e in
+        Promotion_proof ([e], e', [], Dereliction_proof ([], e, [e'], Axiom_proof e))
+    end;;
+
+
+(* OPERATIONS *)
+
 let get_transformation_options_json proof =
     Proof.to_json ~transform_options:true proof;;
 
+let apply_transformation_with_exceptions proof_with_notations = function
+    | Expand_axiom -> match proof_with_notations.proof with
+        | Axiom_proof f -> expand_axiom f
+        | _ -> raise (Transform_exception ("Can only expand axiom on Axiom_proof"))
 
 (* HANDLERS *)
 
@@ -9,3 +70,15 @@ let get_proof_transformation_options request_as_json =
         let proof_with_transformation_options = get_transformation_options_json proof_with_notations.proof in
         true, `Assoc ["proofWithTransformationOptions", proof_with_transformation_options]
     with Proof_with_notations.Json_exception m -> false, `String ("Bad request: " ^ m);;
+
+let apply_transformation request_as_json =
+    try let proof_with_notations = Proof_with_notations.from_json request_as_json in
+        let transform_request_as_json = Request_utils.get_key request_as_json "transformRequest" in
+        let transform_request = Transform_request.from_json transform_request_as_json in
+        let proof = apply_transformation_with_exceptions proof_with_notations transform_request in
+        let proof_with_transformation_options = get_transformation_options_json proof in
+        true, `Assoc ["proofWithTransformationOptions", proof_with_transformation_options]
+    with Proof_with_notations.Json_exception m -> false, `String ("Bad proof with notations: " ^ m)
+        | Request_utils.Bad_request_exception m -> false, `String ("Bad request: " ^ m)
+        | Transform_request.Json_exception m -> false, `String ("Bad transformation request: " ^ m)
+        | Transform_exception m -> false, `String ("Transform exception: " ^ m);;

--- a/proof_transformation.ml
+++ b/proof_transformation.ml
@@ -1,0 +1,11 @@
+let get_transformation_options_json proof =
+    Proof.to_json ~transform_options:true proof;;
+
+
+(* HANDLERS *)
+
+let get_proof_transformation_options request_as_json =
+    try let proof_with_notations = Proof_with_notations.from_json request_as_json in
+        let proof_with_transformation_options = get_transformation_options_json proof_with_notations.proof in
+        true, `Assoc ["proofWithTransformationOptions", proof_with_transformation_options]
+    with Proof_with_notations.Json_exception m -> false, `String ("Bad request: " ^ m);;

--- a/proof_transformation.ml
+++ b/proof_transformation.ml
@@ -5,76 +5,76 @@ open Transform_request
 
 exception Transform_exception of string;;
 
-let expand_axiom formula =
-    match formula with
-    | One -> Axiom_proof formula (* TODO apply Bottom then One ? *)
-    | Bottom -> Axiom_proof formula (* TODO apply Bottom then One ? *)
-    | Top -> Axiom_proof formula (* TODO apply Top ? *)
-    | Zero -> Axiom_proof formula (* TODO apply Top ? *)
-    | Litt _s -> Axiom_proof formula (* TODO notations *)
-    | Dual _s -> Axiom_proof formula (* TODO notations *)
-    | Tensor (e1, e2) -> begin
+let expand_axiom notations = function
+    | One -> Bottom_proof ([One], [], One_proof)
+    | Bottom -> Bottom_proof ([], [One], One_proof)
+    | Top -> Top_proof ([], [Zero])
+    | Zero -> Top_proof ([Zero], [])
+    | Litt s when List.mem_assoc s notations ->
+        let f = Raw_sequent.to_formula (List.assoc s notations) in
+        Unfold_litt_proof ([], s, [Dual s], Unfold_dual_proof ([f], s, [], Axiom_proof f))
+    | Dual s when List.mem_assoc s notations ->
+        let f = Raw_sequent.to_formula (List.assoc s notations) in
+        Unfold_dual_proof ([], s, [Litt s], Unfold_litt_proof ([dual f], s, [], Axiom_proof (dual f)))
+    | Litt s -> Axiom_proof (Litt s)
+    | Dual s -> Axiom_proof (Dual s)
+    | Tensor (e1, e2) ->
          let e1' = dual e1 in
          let e2' = dual e2 in
          let tensor_proof = Tensor_proof ([e1'], e1, e2, [e2'], Axiom_proof e1', Axiom_proof e2) in
          let permutation = [1; 0; 2] in
          let exchange_proof = Exchange_proof ([e1'; Tensor (e1, e2); e2'], permutation, permutation, tensor_proof) in
          Par_proof ([Tensor (e1, e2)], e1', e2', [], exchange_proof)
-     end
-    | Par (e1, e2) -> begin
+    | Par (e1, e2) ->
         let e1' = dual e1 in
         let e2' = dual e2 in
         let tensor_proof = Tensor_proof ([e1], e1', e2', [e2], Axiom_proof e1, Axiom_proof e2') in
         let permutation = [0; 2; 1] in
         let exchange_proof = Exchange_proof ([e1; Tensor (e1', e2'); e2], permutation, permutation, tensor_proof) in
         Par_proof ([], e1, e2, [Tensor (e1', e2')], exchange_proof)
-    end
-    | With (e1, e2) -> begin
+    | With (e1, e2) ->
         let e1' = dual e1 in
         let e2' = dual e2 in
         let plus_left_proof = Plus_left_proof ([e1], e1', e2', [], Axiom_proof e1) in
         let plus_right_proof = Plus_right_proof ([e2], e1', e2', [], Axiom_proof e2) in
         With_proof ([], e1, e2, [Plus (e1', e2')], plus_left_proof, plus_right_proof)
-    end
-    | Plus (e1, e2) -> begin
+    | Plus (e1, e2) ->
        let e1' = dual e1 in
        let e2' = dual e2 in
        let plus_left_proof = Plus_left_proof ([], e1, e2, [e1'], Axiom_proof e1) in
        let plus_right_proof = Plus_right_proof ([], e1, e2, [e2'], Axiom_proof e2) in
        With_proof ([Plus (e1, e2)], e1', e2', [], plus_left_proof, plus_right_proof)
-    end
-    | Ofcourse e -> begin
+    | Ofcourse e ->
        let e' = dual e in
        Promotion_proof ([], e, [e'], Dereliction_proof ([e], e', [], Axiom_proof e))
-    end
-    | Whynot e -> begin
+    | Whynot e ->
         let e' = dual e in
         Promotion_proof ([e], e', [], Dereliction_proof ([], e, [e'], Axiom_proof e))
-    end;;
+    ;;
 
-let rec expand_axiom_full proof =
+let rec expand_axiom_full notations proof =
     let new_proof = match proof with
-        | Axiom_proof f -> expand_axiom f
+        | Axiom_proof f -> expand_axiom notations f
         | _ -> proof in
-    set_premises new_proof (List.map expand_axiom_full (get_premises new_proof))
+    set_premises new_proof (List.map (expand_axiom_full notations) (get_premises new_proof))
 
 (* OPERATIONS *)
 
-let get_transformation_options_json proof =
-    Proof.to_json ~transform_options:true proof;;
+let get_transformation_options_json proof notations =
+    Proof.to_json ~transform_options:true ~notations:notations proof;;
 
 let apply_transformation_with_exceptions proof_with_notations = function
     | Expand_axiom -> begin match proof_with_notations.proof with
-        | Axiom_proof f -> expand_axiom f
+        | Axiom_proof f -> expand_axiom proof_with_notations.notations f
         | _ -> raise (Transform_exception ("Can only expand axiom on Axiom_proof"))
     end
-    | Expand_axiom_full -> expand_axiom_full proof_with_notations.proof;;
+    | Expand_axiom_full -> expand_axiom_full proof_with_notations.notations proof_with_notations.proof;;
 
 (* HANDLERS *)
 
 let get_proof_transformation_options request_as_json =
     try let proof_with_notations = Proof_with_notations.from_json request_as_json in
-        let proof_with_transformation_options = get_transformation_options_json proof_with_notations.proof in
+        let proof_with_transformation_options = get_transformation_options_json proof_with_notations.proof proof_with_notations.notations in
         true, `Assoc ["proofWithTransformationOptions", proof_with_transformation_options]
     with Proof_with_notations.Json_exception m -> false, `String ("Bad request: " ^ m);;
 
@@ -83,7 +83,7 @@ let apply_transformation request_as_json =
         let transform_request_as_json = Request_utils.get_key request_as_json "transformRequest" in
         let transform_request = Transform_request.from_json transform_request_as_json in
         let proof = apply_transformation_with_exceptions proof_with_notations transform_request in
-        let proof_with_transformation_options = get_transformation_options_json proof in
+        let proof_with_transformation_options = get_transformation_options_json proof proof_with_notations.notations in
         true, `Assoc ["proofWithTransformationOptions", proof_with_transformation_options]
     with Proof_with_notations.Json_exception m -> false, `String ("Bad proof with notations: " ^ m)
         | Request_utils.Bad_request_exception m -> false, `String ("Bad request: " ^ m)

--- a/proof_transformation.ml
+++ b/proof_transformation.ml
@@ -52,6 +52,11 @@ let expand_axiom formula =
         Promotion_proof ([e], e', [], Dereliction_proof ([], e, [e'], Axiom_proof e))
     end;;
 
+let rec expand_axiom_full proof =
+    let new_proof = match proof with
+        | Axiom_proof f -> expand_axiom f
+        | _ -> proof in
+    set_premises new_proof (List.map expand_axiom_full (get_premises new_proof))
 
 (* OPERATIONS *)
 
@@ -59,9 +64,11 @@ let get_transformation_options_json proof =
     Proof.to_json ~transform_options:true proof;;
 
 let apply_transformation_with_exceptions proof_with_notations = function
-    | Expand_axiom -> match proof_with_notations.proof with
+    | Expand_axiom -> begin match proof_with_notations.proof with
         | Axiom_proof f -> expand_axiom f
         | _ -> raise (Transform_exception ("Can only expand axiom on Axiom_proof"))
+    end
+    | Expand_axiom_full -> expand_axiom_full proof_with_notations.proof;;
 
 (* HANDLERS *)
 

--- a/proof_with_notations.ml
+++ b/proof_with_notations.ml
@@ -5,23 +5,15 @@ type proof_with_notations = {proof: proof; notations: notations}
 
 exception Json_exception of string
 
-let get_key d k =
-    let value =
-        try Yojson.Basic.Util.member k d
-        with Yojson.Basic.Util.Type_error (_, _) -> raise (Json_exception ("request body must be a json object"))
-    in
-    if value = `Null
-    then raise (Json_exception ("required argument '" ^ k ^ "' is missing"))
-    else value
-
 let from_json proof_with_notations_as_json =
     try
-        let notations_as_json = get_key proof_with_notations_as_json "notations" in
+        let notations_as_json = Request_utils.get_key proof_with_notations_as_json "notations" in
         let notations = Notations.from_json notations_as_json in
-        let proof_as_json = get_key proof_with_notations_as_json "proof" in
+        let proof_as_json = Request_utils.get_key proof_with_notations_as_json "proof" in
         let proof = Proof.from_json notations proof_as_json in
         {proof=proof; notations=notations}
-    with Proof.Json_exception m -> raise (Json_exception ("bad proof json: " ^ m))
+    with Request_utils.Bad_request_exception m -> raise (Json_exception ("bad request: " ^ m))
+         | Proof.Json_exception m -> raise (Json_exception ("bad proof json: " ^ m))
          | Raw_sequent.Json_exception m -> raise (Json_exception ("bad sequent json: " ^ m))
          | Rule_request.Json_exception m -> raise (Json_exception ("bad rule_request json: " ^ m))
          | Proof.Rule_exception (_, m) -> raise (Json_exception ("invalid proof: " ^ m))

--- a/request_utils.ml
+++ b/request_utils.ml
@@ -1,0 +1,15 @@
+exception Bad_request_exception of string
+
+let get_key d k =
+    let value =
+        try Yojson.Basic.Util.member k d
+        with Yojson.Basic.Util.Type_error (_, _) -> raise (Bad_request_exception ("request body must be a json object"))
+    in
+    if value = `Null
+    then raise (Bad_request_exception ("required argument '" ^ k ^ "' is missing"))
+    else value
+
+let get_string d k =
+    let value = get_key d k in
+    try Yojson.Basic.Util.to_string value
+    with Yojson.Basic.Util.Type_error (_, _) -> raise (Bad_request_exception ("field '" ^ k ^ "' must be a string"));;

--- a/sequent_with_notations.ml
+++ b/sequent_with_notations.ml
@@ -5,23 +5,15 @@ type sequent_with_notations = {sequent: sequent; notations: notations}
 
 exception Json_exception of string
 
-let get_key d k =
-    let value =
-        try Yojson.Basic.Util.member k d
-        with Yojson.Basic.Util.Type_error (_, _) -> raise (Json_exception ("request body must be a json object"))
-    in
-    if value = `Null
-    then raise (Json_exception ("required argument '" ^ k ^ "' is missing"))
-    else value
-
 let from_json sequent_with_notations_as_json =
     try
-        let notations_as_json = get_key sequent_with_notations_as_json "notations" in
+        let notations_as_json = Request_utils.get_key sequent_with_notations_as_json "notations" in
         let notations = Notations.from_json notations_as_json in
-        let sequent_as_json = get_key sequent_with_notations_as_json "sequent" in
+        let sequent_as_json = Request_utils.get_key sequent_with_notations_as_json "sequent" in
         let sequent = Raw_sequent.sequent_from_json sequent_as_json in
         {sequent=sequent; notations=notations}
-    with Raw_sequent.Json_exception m -> raise (Json_exception ("bad sequent json: " ^ m))
+    with Request_utils.Bad_request_exception m -> raise (Json_exception ("bad request: " ^ m))
+         | Raw_sequent.Json_exception m -> raise (Json_exception ("bad sequent json: " ^ m))
          | Notations.Json_exception m -> raise (Json_exception ("bad notations: " ^ m))
 
 (* OPERATIONS *)

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -53,6 +53,7 @@ input[type=text], .code { background-color: #FFF; font-family: "Courier New", sa
 
 /* PROOF */
 .proof.complete { background:#CFC; }
+.proof.proof-transformation { background:#e0ecf8; }
 .proof { text-align:center; text-indent: 0; display:table; white-space:nowrap; padding-left: 2.4em; padding-top:0.5em; padding-bottom:0.3em; margin: 0 auto 1em; }
 .proof table { margin: auto; }
 .proof table.binary-rule { width:100%; }

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -75,7 +75,7 @@ input[type=text], .code { background-color: #FFF; font-family: "Courier New", sa
 .proof.cut-mode span.first-point:after, .proof.cut-mode .commaList li:last-child span.comma:after { content: '.'; }
 .proof.cut-mode span.first-point, .proof.cut-mode .commaList li span.comma { cursor: pointer; margin-left: 0.3em; margin-right: 0.3em; }
 .proof .binary-connector { margin-left: 3px; margin-right: 3px; }
-.proof .clickable:hover { cursor:pointer; }
+.proof .clickable { cursor: pointer; }
 .proof .highlightableExpr:hover { background: #e0ecf8; }
 .proof .main-formula.hoverable:hover .primaryConnector { background: #66a3e0; color: #FFF; }
 

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -53,7 +53,7 @@ input[type=text], .code { background-color: #FFF; font-family: "Courier New", sa
 
 /* PROOF */
 .proof.complete { background:#CFC; }
-.proof.proof-transformation { background:#e0ecf8; }
+.proof.proof-transformation { border: 2px dashed #66a3e0; }
 .proof { text-align:center; text-indent: 0; display:table; white-space:nowrap; padding-left: 2.4em; padding-top:0.5em; padding-bottom:0.3em; margin: 0 auto 1em; }
 .proof table { margin: auto; }
 .proof table.binary-rule { width:100%; }
@@ -78,6 +78,9 @@ input[type=text], .code { background-color: #FFF; font-family: "Courier New", sa
 .proof .clickable { cursor: pointer; }
 .proof .highlightableExpr:hover { background: #e0ecf8; }
 .proof .main-formula.hoverable:hover .primaryConnector { background: #66a3e0; color: #FFF; }
+.transform-button { margin-left: 0.1em; }
+.transform-button.enabled:hover { cursor: pointer; background: #66a3e0; color: #FFF; }
+.transform-button.disabled { color: #ccc; }
 
 .export-bar, .option-bar { margin-left: auto; margin-right: auto; display: table; }
 .export-bar { margin-top: 1em; }

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -88,6 +88,9 @@ function initMainProof(proofAsJson) {
     // We get cut mode option in URL
     let cutMode = getQueryParamInUrl('cut_mode') === '1';
 
+    // We get proof transformation option in URL
+    let proofTransformation = getQueryParamInUrl('proof_transformation') === '1';
+
     // We get notations from URL
     let notations = getQueryPairListParamInUrl('n');
 
@@ -102,6 +105,10 @@ function initMainProof(proofAsJson) {
         cutMode: {
             value: cutMode,
             onToggle: onOptionToggle('cut_mode')
+        },
+        proofTransformation: {
+            value: proofTransformation,
+            onToggle: onOptionToggle('proof_transformation')
         },
         notations: {
             formulasAsString: notations,

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -50,6 +50,9 @@ function submitSequent(element, autoSubmit = false) {
 
         // We update current URL by adding sequent in query parameters
         addQueryParamInUrl('s', sequentAsString.toString(), 'Linear logic proof start');
+
+        // We set proof_transformation to false
+        addQueryParamInUrl('proof_transformation', null, `proof_transformation set to false`);
     }
 
     // Add GA events

--- a/static/js/proof.js
+++ b/static/js/proof.js
@@ -253,14 +253,18 @@ function addPremises($sequentTable, proofAsJson, permutationBeforeRule, options)
         })
     } else if (options.proofTransformation.value) {
         for (let transformOption of proofAsJson.appliedRule.transformOptions) {
-            let $transformSpan = $('<span>', {'class': 'clickable'})
-                .text(TRANSFORM_OPTIONS[transformOption].button)
-                .attr('title', TRANSFORM_OPTIONS[transformOption].title);
-            addClickAndDoubleClickEvent($transformSpan, function () {
-                applyTransformation($sequentTable, TRANSFORM_OPTIONS[transformOption].singleClick);
-            }, function () {
-                applyTransformation($sequentTable, TRANSFORM_OPTIONS[transformOption].doubleClick);
-            });
+            let transformation = transformOption.transformation;
+            let $transformSpan = $('<span>', {'class': 'transform-button'})
+                .addClass(transformOption.enabled ? 'enabled' : 'disabled')
+                .text(TRANSFORM_OPTIONS[transformation].button);
+            if (transformOption.enabled) {
+                $transformSpan.attr('title', TRANSFORM_OPTIONS[transformation].title);
+                addClickAndDoubleClickEvent($transformSpan, function () {
+                    applyTransformation($sequentTable, TRANSFORM_OPTIONS[transformation].singleClick);
+                }, function () {
+                    applyTransformation($sequentTable, TRANSFORM_OPTIONS[transformation].doubleClick);
+                });
+            }
             $ruleSymbol.append($transformSpan);
         }
     }

--- a/static/js/proof.js
+++ b/static/js/proof.js
@@ -24,7 +24,12 @@ const RULES = {
 };
 
 const TRANSFORM_OPTIONS = {
-    'expand_axiom': {'button': '⇯', 'title': 'Expand axiom'}
+    'expand_axiom': {
+        'button': '⇯',
+        'title': 'One step axiom expansion (single click) or full axiom expansion (double click)',
+        'singleClick': 'expand_axiom',
+        'doubleClick': 'expand_axiom_full'
+    }
 };
 
 const ABBREVIATIONS = {
@@ -248,12 +253,15 @@ function addPremises($sequentTable, proofAsJson, permutationBeforeRule, options)
         })
     } else if (options.proofTransformation.value) {
         for (let transformOption of proofAsJson.appliedRule.transformOptions) {
-            $ruleSymbol.append($('<span>', {'class': 'clickable'})
+            let $transformSpan = $('<span>', {'class': 'clickable'})
                 .text(TRANSFORM_OPTIONS[transformOption].button)
-                .attr('title', TRANSFORM_OPTIONS[transformOption].title)
-                .on('click', function() {
-                    applyTransformation($sequentTable, transformOption);
-                }));
+                .attr('title', TRANSFORM_OPTIONS[transformOption].title);
+            addClickAndDoubleClickEvent($transformSpan, function () {
+                applyTransformation($sequentTable, TRANSFORM_OPTIONS[transformOption].singleClick);
+            }, function () {
+                applyTransformation($sequentTable, TRANSFORM_OPTIONS[transformOption].doubleClick);
+            });
+            $ruleSymbol.append($transformSpan);
         }
     }
     $td.next('.tagBox').html($ruleSymbol);

--- a/transform_request.ml
+++ b/transform_request.ml
@@ -1,0 +1,19 @@
+type transform_request =
+    | Expand_axiom;;
+
+(* JSON -> TRANSFORM REQUEST *)
+
+exception Json_exception of string;;
+
+let from_json transform_request_as_json =
+    try let transformation = Request_utils.get_string transform_request_as_json "transformation" in
+        match transformation with
+            | "expand_axiom" -> Expand_axiom
+            | _ -> raise (Json_exception ("unknown transformation '" ^ transformation ^ "'"))
+    with Request_utils.Bad_request_exception m -> raise (Json_exception ("bad request: " ^ m));;
+
+(* TRANSFORM REQUEST-> STRING *)
+
+let to_string = function
+    | Expand_axiom -> "expand_axiom"
+    ;;

--- a/transform_request.ml
+++ b/transform_request.ml
@@ -1,5 +1,6 @@
 type transform_request =
-    | Expand_axiom;;
+    | Expand_axiom
+    | Expand_axiom_full;;
 
 (* JSON -> TRANSFORM REQUEST *)
 
@@ -9,6 +10,7 @@ let from_json transform_request_as_json =
     try let transformation = Request_utils.get_string transform_request_as_json "transformation" in
         match transformation with
             | "expand_axiom" -> Expand_axiom
+            | "expand_axiom_full" -> Expand_axiom_full
             | _ -> raise (Json_exception ("unknown transformation '" ^ transformation ^ "'"))
     with Request_utils.Bad_request_exception m -> raise (Json_exception ("bad request: " ^ m));;
 
@@ -16,4 +18,5 @@ let from_json transform_request_as_json =
 
 let to_string = function
     | Expand_axiom -> "expand_axiom"
+    | Expand_axiom_full -> "expand_axiom_full"
     ;;


### PR DESCRIPTION
In this first PR :
- transformation mode: freezes proof and add buttons of proof transformation (returned by backend)
- one-step axiom expansion

Contains a refacto of json parsing -> see request_utils.ml

Deployed on preprod : https://ccll.linear-logic.org/?s=A*B%2BC+%7C-+A*B%2BC&p=XQAAgAD%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FwA9iIoHZADSvL4AO2WnajJ4cSZ3uOM1Jm1oajsTKyplYJRzmD1My8ZPN9MCAxsFHaPv%2Ft7s2GD9kDaL%2BpvLgaFmin3ixkHOVjUK%2FIhy5XpuakWRf%2FPo7yR0hgAl38CCooAkdOBs%2F0SbKWqLVPkDdiiodkj5nKxinFvGN%2BSFKgkdtLpC9byiKAtFb%2Bivu8g9L2UAlW9VjCeEoZp7xhiWioYBeK9KHPfnO%2FyBjqY%3D&proof_transformation=1