### PR TITLE
Apply reversible first

### DIFF
--- a/index.html
+++ b/index.html
@@ -194,6 +194,10 @@
                 <li>Click on ↑ to eliminate a cut rule on key-case.</li>
                 <li>Click on ✄ to eliminate a specific cut completely (disabled on proof with recursive notations).</li>
             </ul>
+            <p>Inside sequents:</p>
+            <ul>
+                <li>Click on reversible connectives (<span class="flip">&</span>, &, ⊥, ⊤, !) to apply them first.</li>
+            </ul>
             <p>Some global action buttons will also appear below proof:</p>
             <ul>
                 <li>Click on ↶ (resp. ↷) button below proof to undo (resp. redo) last transformation.</li>

--- a/proof_transformation.ml
+++ b/proof_transformation.ml
@@ -778,8 +778,12 @@ let rec commute_down_reversible position formulas notations = function
             Cut_proof (new_head, f, tail, commute_down_reversible position formulas notations p1, p2)
         else Cut_proof (head, f, new_tail, p1, commute_down_reversible (position - List.length head + 1) formulas notations p2)
     | Exchange_proof (_, _display_permutation, permutation, p) ->
-        let new_perm = perm_plus_element position permutation in
         let new_position = List.nth permutation position in
+        let new_perm = match formulas with
+        | [] -> perm_minus_element new_position permutation
+        | [_] -> permutation
+        | [_; _] -> perm_plus_element new_position permutation
+        | _ -> raise (Failure "formulas with more than 2 elements") in
         let new_proof = commute_down_reversible new_position formulas notations p in
         Exchange_proof (get_conclusion new_proof, new_perm, new_perm, new_proof)
     | Hypothesis_proof sequent -> let new_sequent, _, _ = replace_at_length position formulas 0 sequent [] in

--- a/proof_transformation.ml
+++ b/proof_transformation.ml
@@ -5,6 +5,7 @@ open Transform_request
 open Permutations
 
 exception Transform_exception of string;;
+exception Pedagogic_exception of string;;
 
 (* PROOF -> TRANSFORM OPTION *)
 
@@ -669,7 +670,6 @@ let rec eliminate_cut_key_case cut_head cut_formula cut_tail cut_p1 cut_p2 perm1
         eliminate_cut_key_case cut_head cut_formula cut_tail cut_p1 p perm1 (permute perm2 exchange_permutation) notations cut_trans
     | _ -> raise (Failure "Can not eliminate cut key-case on these two proofs")
 
-
 let rec cut_elimination_key_case notations cut_trans = function
     | Cut_proof (cut_head, cut_formula, cut_tail, cut_p1, cut_p2) ->
         eliminate_cut_key_case cut_head cut_formula cut_tail cut_p1 cut_p2 (identity (List.length cut_head + 1)) (identity (List.length cut_tail + 1)) notations cut_trans
@@ -707,6 +707,122 @@ let rec eliminate_all_cuts_in_proof acyclic_notations = function
         merge_exchange (Exchange_proof (s, display_permutation, exchange_permutation, eliminate_all_cuts_in_proof acyclic_notations p))
     | proof -> set_premises proof (List.map (eliminate_all_cuts_in_proof acyclic_notations) (get_premises proof))
 
+(* COMMUTE DOWN REVERSIBLE RULES *)
+
+let replace_at_length position formulas offset head tail =
+    if position < List.length head then
+         let head1, _, head2 = head_formula_tail position head in
+         head1 @ formulas @ head2, tail, position
+    else let tail1, _, tail2 = head_formula_tail (position - List.length head - 1) tail in
+        head, tail1 @ formulas @ tail2, position + offset
+
+let rec commute_down_reversible position formulas notations = function
+    | Axiom_proof e -> commute_down_reversible position formulas notations (expand_axiom notations e)
+    | One_proof -> raise (Failure "One_proof not expected")
+    | Top_proof (head, tail) ->
+        let new_head, new_tail, _ = replace_at_length position formulas 0 head tail in
+        Top_proof (new_head, new_tail)
+    | Bottom_proof (head, tail, p) ->
+        if List.length head = position
+        then p
+        else let new_head, new_tail, new_position = replace_at_length position formulas (-1) head tail in
+            Bottom_proof (new_head, new_tail, commute_down_reversible new_position formulas notations p)
+    | Tensor_proof (head, e1, e2, tail, p1, p2) ->
+        let new_head, new_tail, _ = replace_at_length position formulas 0 head tail in
+        if position < List.length head then
+            Tensor_proof (new_head, e1, e2, tail, commute_down_reversible position formulas notations p1, p2)
+        else Tensor_proof (head, e1, e2, new_tail, p1, commute_down_reversible (position - List.length head) formulas notations p2)
+    | Par_proof (head, e1, e2, tail, p) ->
+        if List.length head = position
+        then p
+        else let new_head, new_tail, new_position = replace_at_length position formulas 1 head tail in
+            Par_proof (new_head, e1, e2, new_tail, commute_down_reversible new_position formulas notations p)
+    | With_proof (head, e1, e2, tail, p1, p2) ->
+        if List.length head = position
+        then match formulas with
+            | [e] when e = e1 -> p1
+            | [e] when e = e2 -> p2
+            | _ -> raise (Failure ("Formulas of that type not expected: " ^ (Sequent.sequent_to_ascii false formulas)))
+        else let new_head, new_tail, new_position = replace_at_length position formulas 0 head tail in
+            let new_p1 = commute_down_reversible new_position formulas notations p1 in
+            let new_p2 = commute_down_reversible new_position formulas notations p2 in
+            With_proof (new_head, e1, e2, new_tail, new_p1, new_p2)
+    | Plus_left_proof (head, e1, e2, tail, p) ->
+        let new_head, new_tail, new_position = replace_at_length position formulas 0 head tail in
+        Plus_left_proof (new_head, e1, e2, new_tail, commute_down_reversible new_position formulas notations p)
+    | Plus_right_proof (head, e1, e2, tail, p) ->
+        let new_head, new_tail, new_position = replace_at_length position formulas 0 head tail in
+        Plus_right_proof (new_head, e1, e2, new_tail, commute_down_reversible new_position formulas notations p)
+    | Promotion_proof (head_without_whynot, _e, _tail_without_whynot, p) ->
+        if List.length head_without_whynot = position
+        then p
+        else raise (Failure "Promotion_proof not expected")
+    | Dereliction_proof (head, e, tail, p) ->
+        let new_head, new_tail, new_position = replace_at_length position formulas 0 head tail in
+        Dereliction_proof (new_head, e, new_tail, commute_down_reversible new_position formulas notations p)
+    | Weakening_proof (head, e, tail, p) ->
+        let new_head, new_tail, new_position = replace_at_length position formulas (-1) head tail in
+        Weakening_proof (new_head, e, new_tail, commute_down_reversible new_position formulas notations p)
+    | Contraction_proof (head, e, tail, p) ->
+        let new_head, new_tail, new_position = replace_at_length position formulas 1 head tail in
+        Contraction_proof (new_head, e, new_tail, commute_down_reversible new_position formulas notations p)
+    | Unfold_litt_proof (head, s, tail, p) ->
+        let new_head, new_tail, new_position = replace_at_length position formulas 0 head tail in
+        Unfold_litt_proof (new_head, s, new_tail, commute_down_reversible new_position formulas notations p)
+    | Unfold_dual_proof (head, s, tail, p) ->
+        let new_head, new_tail, new_position = replace_at_length position formulas 0 head tail in
+        Unfold_dual_proof (new_head, s, new_tail, commute_down_reversible new_position formulas notations p)
+    | Cut_proof (head, f, tail, p1, p2) ->
+        let new_head, new_tail, _ = replace_at_length position formulas 0 head tail in
+        if position < List.length head then
+            Cut_proof (new_head, f, tail, commute_down_reversible position formulas notations p1, p2)
+        else Cut_proof (head, f, new_tail, p1, commute_down_reversible (position - List.length head + 1) formulas notations p2)
+    | Exchange_proof (_, _display_permutation, permutation, p) ->
+        let new_perm = perm_plus_element position permutation in
+        let new_position = List.nth permutation position in
+        let new_proof = commute_down_reversible new_position formulas notations p in
+        Exchange_proof (get_conclusion new_proof, new_perm, new_perm, new_proof)
+    | Hypothesis_proof sequent -> let new_sequent, _, _ = replace_at_length position formulas 0 sequent [] in
+        Hypothesis_proof new_sequent
+
+let apply_reversible_first notations rule_request proof =
+    let sequent = get_conclusion proof in
+    match rule_request with
+    | Rule_request.Bottom formula_position -> begin
+        let head, formula, tail = head_formula_tail formula_position sequent in
+        match formula with
+        | Bottom -> Bottom_proof (head, tail, commute_down_reversible formula_position [] notations proof)
+        | _ -> raise (Transform_exception "Can not apply 'bottom' rule")
+    end
+    | Rule_request.Top formula_position -> begin
+        let head, formula, tail = head_formula_tail formula_position sequent in
+        match formula with
+        | Top -> Top_proof (head, tail)
+        | _ -> raise (Transform_exception "Can not apply 'top' rule")
+    end
+    | Rule_request.Par formula_position -> begin
+        let head, formula, tail = head_formula_tail formula_position sequent in
+        match formula with
+        | Par (e1, e2) -> Par_proof (head, e1, e2, tail, commute_down_reversible formula_position [e1; e2] notations proof)
+        | _ -> raise (Transform_exception "Can not apply 'par' rule")
+    end
+    | Rule_request.With formula_position -> begin
+        let head, formula, tail = head_formula_tail formula_position sequent in
+        match formula with
+        | With (e1, e2) -> With_proof (head, e1, e2, tail, commute_down_reversible formula_position [e1] notations proof, commute_down_reversible formula_position [e2] notations proof)
+        | _ -> raise (Transform_exception "Can not apply 'with' rule")
+    end
+    | Rule_request.Promotion formula_position -> begin
+        let head, formula, tail = head_formula_tail formula_position sequent in
+        try let head_without_whynot = remove_whynot head in
+            let tail_without_whynot = remove_whynot tail in
+            match formula with
+            | Ofcourse e -> Promotion_proof (head_without_whynot, e, tail_without_whynot, commute_down_reversible formula_position [e] notations proof)
+            | _ -> raise (Transform_exception "Can not apply 'promotion' rule on non Ofcourse formula")
+        with Not_whynot -> raise (Pedagogic_exception "Can not apply 'promotion' rule: the context must contain formulas starting by '?' only.")
+    end
+    | _ -> raise (Transform_exception "Not a reversible rule")
+
 (* OPERATIONS *)
 
 let get_transformation_options_json proof notations not_cyclic =
@@ -728,6 +844,7 @@ let apply_transformation_with_exceptions proof cyclic_notations acyclic_notation
     | Eliminate_all_cuts -> eliminate_all_cuts_in_proof acyclic_notations proof
     | Simplify -> Proof_simplification.simplify proof
     | Substitute (alias, raw_formula) -> Proof.replace_in_proof alias (Raw_sequent.to_formula raw_formula) proof
+    | Apply_reversible_first rule_request -> apply_reversible_first (cyclic_notations @ acyclic_notations) rule_request proof
     ;;
 
 let apply_transformation_on_notations notations = function
@@ -764,4 +881,5 @@ let apply_transformation request_as_json =
     with Proof_with_notations.Json_exception m -> false, `String ("Bad proof with notations: " ^ m)
         | Request_utils.Bad_request_exception m -> false, `String ("Bad request: " ^ m)
         | Transform_request.Json_exception m -> false, `String ("Bad transformation request: " ^ m)
-        | Transform_exception m -> false, `String ("Transform exception: " ^ m);;
+        | Transform_exception m -> false, `String ("Transform exception: " ^ m)
+        | Pedagogic_exception m -> true, `Assoc ["error_message", `String m];;

--- a/request_utils.ml
+++ b/request_utils.ml
@@ -13,8 +13,3 @@ let get_string d k =
     let value = get_key d k in
     try Yojson.Basic.Util.to_string value
     with Yojson.Basic.Util.Type_error (_, _) -> raise (Bad_request_exception ("field '" ^ k ^ "' must be a string"))
-
-let get_raw_formula d k =
-    let value = get_key d k in
-    try Raw_sequent.json_to_raw_formula value
-    with Raw_sequent.Json_exception m -> raise (Bad_request_exception ("field '" ^ k ^ "' must contain a valid formula: " ^ m))

--- a/static/js/proof.js
+++ b/static/js/proof.js
@@ -274,7 +274,6 @@ function addPremises($sequentTable, proofAsJson, permutationBeforeRule, options)
         $td.children('.tagBox').append(transformDiv);
     }
 
-
     // Add premises
     let premises = proofAsJson.appliedRule.premises;
     if (premises.length === 0) {
@@ -1093,10 +1092,14 @@ function applyTransformation($sequentTable, transformRequest) {
         data: compressJson(JSON.stringify({ proof, notations, transformRequest })),
         success: function(data)
         {
-            clearSavedProof();
-            cleanPedagogicMessage($container);
-            saveNotations($container, data['notations']);
-            replaceAndReloadProof($sequentTable, data['proof'], $container);
+            if (data['error_message']) {
+                displayPedagogicError(data['error_message'], $container);
+            } else {
+                clearSavedProof();
+                cleanPedagogicMessage($container);
+                saveNotations($container, data['notations']);
+                replaceAndReloadProof($sequentTable, data['proof'], $container);
+            }
         },
         error: onAjaxError
     });

--- a/test/api_test_data.json
+++ b/test/api_test_data.json
@@ -1067,6 +1067,9 @@
       "transformRequest":{"transformation":"expand_axiom_full"}},
     {"proof":{"s":{"cons":[{"t":"tensor","v1":{"t":"one"},"v2":{"t":"dual","v":{"t":"litt","v":"A"}}},{"t":"par","v1":{"t":"litt","v":"A"},"v2":{"t":"bottom"}}]},"ar":{"rr":{"r":"tensor","fp":0},"p":[{"s":{"cons":[{"t":"one"}]},"ar":{"rr":{"r":"one"},"p":[]}},{"s":{"cons":[{"t":"dual","v":{"t":"litt","v":"A"}},{"t":"par","v1":{"t":"litt","v":"A"},"v2":{"t":"bottom"}}]},"ar":{"rr":{"r":"par","fp":1},"p":[{"s":{"cons":[{"t":"dual","v":{"t":"litt","v":"A"}},{"t":"litt","v":"A"},{"t":"bottom"}]},"ar":{"rr":{"r":"bottom","fp":2},"p":[{"s":{"cons":[{"t":"dual","v":{"t":"litt","v":"A"}},{"t":"litt","v":"A"}]},"ar":{"rr":{"r":"axiom"},"p":[]}}]}}]}}]}},
       "notations":[],
+      "transformRequest":{"transformation":"apply_reversible_first","rr":{"r":"par","fp":1}}},
+    {"proof":{"s":{"cons":[{"t":"bottom"},{"t":"par","v1":{"t":"litt","v":"A"},"v2":{"t":"dual","v":{"t":"litt","v":"A"}}}]},"ar":{"rr":{"r":"exchange","permutation":[1,0],"displayPermutation":[1,0]},"p":[{"s":{"cons":[{"t":"par","v1":{"t":"litt","v":"A"},"v2":{"t":"dual","v":{"t":"litt","v":"A"}}},{"t":"bottom"}]},"ar":{"rr":{"r":"par","fp":0},"p":[{"s":{"cons":[{"t":"litt","v":"A"},{"t":"dual","v":{"t":"litt","v":"A"}},{"t":"bottom"}]},"ar":{"rr":{"r":"bottom","fp":2},"p":[{"s":{"cons":[{"t":"litt","v":"A"},{"t":"dual","v":{"t":"litt","v":"A"}}]},"ar":{"rr":{"r":"axiom"},"p":[]}}]}}]}}]}},
+      "notations":[],
       "transformRequest":{"transformation":"apply_reversible_first","rr":{"r":"par","fp":1}}}
   ]
 }

--- a/test/api_test_data.json
+++ b/test/api_test_data.json
@@ -1064,6 +1064,9 @@
       "transformRequest":{"transformation":"eliminate_cut_left"}},
     {"proof":{"s":{"cons":[{"t":"one"},{"t":"bottom"}]},"ar":{"rr":{"r":"axiom"},"p":[]}},
       "notations":[],
-      "transformRequest":{"transformation":"expand_axiom_full"}}
+      "transformRequest":{"transformation":"expand_axiom_full"}},
+    {"proof":{"s":{"cons":[{"t":"tensor","v1":{"t":"one"},"v2":{"t":"dual","v":{"t":"litt","v":"A"}}},{"t":"par","v1":{"t":"litt","v":"A"},"v2":{"t":"bottom"}}]},"ar":{"rr":{"r":"tensor","fp":0},"p":[{"s":{"cons":[{"t":"one"}]},"ar":{"rr":{"r":"one"},"p":[]}},{"s":{"cons":[{"t":"dual","v":{"t":"litt","v":"A"}},{"t":"par","v1":{"t":"litt","v":"A"},"v2":{"t":"bottom"}}]},"ar":{"rr":{"r":"par","fp":1},"p":[{"s":{"cons":[{"t":"dual","v":{"t":"litt","v":"A"}},{"t":"litt","v":"A"},{"t":"bottom"}]},"ar":{"rr":{"r":"bottom","fp":2},"p":[{"s":{"cons":[{"t":"dual","v":{"t":"litt","v":"A"}},{"t":"litt","v":"A"}]},"ar":{"rr":{"r":"axiom"},"p":[]}}]}}]}}]}},
+      "notations":[],
+      "transformRequest":{"transformation":"apply_reversible_first","rr":{"r":"par","fp":1}}}
   ]
 }


### PR DESCRIPTION
Specs:
> click on a reversible connective (including ! in ?-context): applies the corresponding rule and do the corresponding reversing in  the above proof (may require some axiom expansion steps, and modifying hypotheses as well)

Can not apply on preprod now, due to maintenance.